### PR TITLE
add csharp 8.0

### DIFF
--- a/compiler/install.sh
+++ b/compiler/install.sh
@@ -7,3 +7,19 @@ echo 'Install Python(PyPy)'
 wget https://bitbucket.org/pypy/pypy/downloads/pypy3.6-v7.1.1-linux64.tar.bz2
 tar -xf pypy3.6-v7.1.1-linux64.tar.bz2 -C /opt
 ln -s /opt/pypy3.6-v7.1.1-linux64/bin/pypy3 /usr/bin/pypy3
+
+echo 'Install .NET Core'
+wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+apt install -y  ./packages-microsoft-prod.deb
+add-apt-repository universe
+apt install -y apt-transport-https
+apt update
+apt install dotnet-sdk-3.0 -y
+
+echo 'Init C# Project'
+dirname="/root/library-checker-judge/compiler"
+project_name="C-Sharp"
+
+dotnet new console -o ${dirname}/${project_name} -lang "C#"
+sed -i -e '/<PropertyGroup>/a <AllowUnsafeBlocks>true</AllowUnsafeBlocks>' ${dirname}/${project_name}/${project_name}.csproj
+dotnet add ${dirname}/${project_name} package System.Runtime.CompilerServices.Unsafe -v 4.6.0

--- a/compiler/langs.toml
+++ b/compiler/langs.toml
@@ -29,3 +29,10 @@
     source = "main.hs"
     compile = "ghc -O2 main.hs"
     exec = "./main"
+[langs.csharp]
+    source = "main.cs"
+    compile = """
+cp -r /root/library-checker-judge/compiler/C-Sharp C-Sharp
+cp main.cs C-Sharp/Program.cs
+dotnet publish C-Sharp -c Release -r ubuntu.18.04-x64 /p:PublishReadyToRun=true -o bin"""
+    exec = "C-Sharp/bin/C-Sharp"

--- a/judge/judge_test.go
+++ b/judge/judge_test.go
@@ -171,6 +171,20 @@ func TestAplusbHaskellAC(t *testing.T) {
 	}
 }
 
+func TestAplusbCSharpAC(t *testing.T) {
+	judge := generateAplusB(t, "csharp", "ac.cs")
+	in := strings.NewReader("1 1")
+	expect := strings.NewReader("2")
+	result, err := judge.TestCase(in, expect)
+	log.Println(judge.dir)
+	if err != nil {
+		t.Fatal("error Run Test", err)
+	}
+	if result.Status != "AC" {
+		t.Fatal("error Status", result)
+	}
+}
+
 func TestAplusbWA(t *testing.T) {
 	judge := generateAplusB(t, "cpp", "wa.cpp")
 	in := strings.NewReader("1 1")

--- a/judge/main_test.go
+++ b/judge/main_test.go
@@ -311,6 +311,39 @@ func TestSubmitHaskellAC(t *testing.T) {
 	}
 }
 
+func TestSubmitCSharpAC(t *testing.T) {
+	src, err := os.Open("test_src/aplusb/ac.cs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	id, err := Submit(db, "aplusb", "csharp", src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Log("submit ok ", id)
+	err = execJudge(db, Task{id})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var submission Submission
+	if err = db.
+		Preload("Problem", func(db *gorm.DB) *gorm.DB {
+			return db.Select("name, title, testhash")
+		}).
+		Where("id = ?", id).Take(&submission).Error; err != nil {
+		t.Fatal(err)
+	}
+	if submission.Status != "AC" {
+		t.Fatal("Expect status AC, actual ", submission.Status)
+	}
+	if !(1 <= submission.MaxTime && submission.MaxTime <= 100) {
+		t.Fatal("Irregural consume time ", submission.MaxTime)
+	}
+	if !(1 <= submission.MaxMemory && submission.MaxMemory <= 10_000_000) {
+		t.Fatal("Irregural consume memory ", submission.MaxMemory)
+	}
+}
+
 func TestSubmitPythonAC(t *testing.T) {
 	src, err := os.Open("test_src/aplusb/ac.py")
 	if err != nil {

--- a/judge/test_src/aplusb/ac.cs
+++ b/judge/test_src/aplusb/ac.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Linq;
+
+static class P
+{
+    static void Main()
+    {
+        int[] ab = Console.ReadLine().Split().Select(int.Parse).ToArray();
+        Console.WriteLine(ab.Sum());
+    }
+}


### PR DESCRIPTION
# 概要
C#8.0(.NET Core 3.0)を追加します。
AtCoderの[言語アップデート](https://docs.google.com/spreadsheets/d/1PmsqufkF3wjKN6g1L0STS80yP4a6u-VdGiEv5uOHe0M/edit#gid=0)にて議論された環境と同一のものです。
Haskellの追加の際に加えたテストと同等のものを追加しました。([TestCSharpAC](https://github.com/key-moon/library-checker-judge/blob/07245b4201e633dfdb234b0dbdc9bca90c6e391d/judge/judge_test.go#L174), [TestSubmitCSharpAC](https://github.com/key-moon/library-checker-judge/blob/07245b4201e633dfdb234b0dbdc9bca90c6e391d/judge/main_test.go#L314))
# インストールについて
パッケージファイルをインストールする必要があるため、`cloudinit.yml`内の`packages`でインストールすることは諦め、`install.sh`内で行うことにしました。`packages`でインストールしたほうが良いと思うので、もし方法があるならそちらに修正して頂きたいです。
また、以下に述べるプロジェクトファイルの作成もこのインストール時に同時に行うことにしました。
# コンパイルについて
dotnetコマンドはプロジェクト単位でコンパイルすることしかできず、単一ファイルのみをコンパイルすることは難しいです。そのため、`/root/library-checker-judge/compiler`下に設定を終えたプロジェクトを作成、その後コンパイル時に一時ディレクトリ下にコピーするようにしました。

https://github.com/key-moon/library-checker-judge/blob/07245b4201e633dfdb234b0dbdc9bca90c6e391d/compiler/install.sh#L19-L25

https://github.com/key-moon/library-checker-judge/blob/07245b4201e633dfdb234b0dbdc9bca90c6e391d/compiler/langs.toml#L32-L38

コンパイル時にディレクトリへのread権限が与えられない場合は上手く行かないことが想定されるため、その場合はプロジェクトファイルを作成するディレクトリを変えて頂けるとありがたいです。