### PR TITLE
Add `--edition 2018` to Rust

### DIFF
--- a/api/langs.toml
+++ b/api/langs.toml
@@ -28,7 +28,7 @@
     name = "Rust"
     version = "rustc(ubuntu20.04 apt)"
     source = "main.rs"
-    compile = "rustc -O main.rs"
+    compile = "rustc --edition 2018 -O main.rs"
     exec = "./main"
 [[langs]]
     id = "d"


### PR DESCRIPTION
Rustはversionとは別にeditionというものがあります。現在は2015 editionと2018 edtionがあり、来年には2021 editionが来る予定です。

[What are Editions? - The Edition Guide](https://doc.rust-lang.org/edition-guide/editions/index.html)

2015 edition → 2018 edtionには破壊的変更が含まれてますがRustでは後方互換性を重視しているため、Rust 2015のコードでも最新のidiomaticなコードを書いていればそのまま移行できるようになっています。2015で許容されたコードが2018では許容されなくなるということは変わりはありませんが、移行のための自動修正ツールも`cargo`に入っています。

AtCoderやCodeforces等のコンテストサイトは既に2018 editionを使っています。ただいくつかの競プロサイトでversionが新しいのにeditionが2015のままであると知っても私はあまり関心は持ちませんでした。競技プログラミングにおいてはあまり問題は起きないだろうと思っていたからです。

しかしモジュールシステムとなると私が考えていたよりも2015と2018の違いは大きかったようです。逆に2018で許容され2015では許されない場合がいくつかあり、2018感覚で書くとそれらに割と引っ掛ります。ざっと最近のLibrary-Checkerの`("Rust", "CE")`を見ただけでも私を含め、複数の人が引っ掛ってました。これらのコードは`--edition 2015`でコンパイルに失敗し、`--edition 2018`で成功します。

- [Submission #24610 - Library-Checker](https://judge.yosupo.jp/submission/24610)
- [Submission #25319 - Library-Checker](https://judge.yosupo.jp/submission/25319)
- [Submission #25470 - Library-Checker](https://judge.yosupo.jp/submission/25470)

[現在の各プラットフォームで使えるRust](https://github.com/rust-lang-ja/atcoder-rust-resources/wiki/Since-1.15.1#%E7%8F%BE%E5%9C%A8%E3%81%AE%E5%90%84%E3%83%97%E3%83%A9%E3%83%83%E3%83%88%E3%83%95%E3%82%A9%E3%83%BC%E3%83%A0%E3%81%A7%E4%BD%BF%E3%81%88%E3%82%8Brust) (さっき更新しました)
