### PR TITLE
change rust opt-level

### DIFF
--- a/langs/langs.toml
+++ b/langs/langs.toml
@@ -34,7 +34,7 @@
     version = "rustc(1.60 edition 2018)"
     source = "main.rs"
     image_name = "library-checker-images-rust"
-    compile = ["rustc", "--edition", "2018", "-O", "main.rs"]
+    compile = ["rustc", "--edition", "2018", "-C opt-level=3", "main.rs"]
     exec = ["./main"]
 [[langs]]
     id = "d"

--- a/langs/langs.toml
+++ b/langs/langs.toml
@@ -34,7 +34,7 @@
     version = "rustc(1.60 edition 2018)"
     source = "main.rs"
     image_name = "library-checker-images-rust"
-    compile = ["rustc", "--edition", "2018", "-C opt-level=3", "main.rs"]
+    compile = ["rustc", "--edition", "2018", "-C", "opt-level=3", "main.rs"]
     exec = ["./main"]
 [[langs]]
     id = "d"


### PR DESCRIPTION
Rust の一般的に使われている release ビルドは opt-level=3 のようなので、それに合わせたい
https://doc.rust-lang.org/stable/book/ch14-01-release-profiles.html 