### PR TITLE
add crystal and ruby

### DIFF
--- a/judge/judge_test.go
+++ b/judge/judge_test.go
@@ -134,6 +134,12 @@ func TestJavaAplusBAC(t *testing.T) {
 func TestGoAplusBAC(t *testing.T) {
 	testAplusBAC(t, "go", "ac.go")
 }
+func TestCrystalAplusBAC(t *testing.T) {
+	testAplusBAC(t, "crystal", "ac.cr")
+}
+func TestRubyAplusBAC(t *testing.T) {
+	testAplusBAC(t, "ruby", "ac.rb")
+}
 
 func TestAplusBWA(t *testing.T) {
 	judge := generateAplusBJudge(t, "cpp", "wa.cpp")

--- a/judge/sources/aplusb/ac.cr
+++ b/judge/sources/aplusb/ac.cr
@@ -1,0 +1,2 @@
+a, b = gets.to_s.split.map(&.to_i64)
+pp a + b

--- a/judge/sources/aplusb/ac.rb
+++ b/judge/sources/aplusb/ac.rb
@@ -1,0 +1,2 @@
+a, b = gets.split.map(&:to_i)
+pp a + b

--- a/langs/Dockerfile.CRYSTAL
+++ b/langs/Dockerfile.CRYSTAL
@@ -1,0 +1,6 @@
+FROM ekidd/rust-musl-builder:latest as init-builder
+COPY --chown=rust:rust init .
+RUN cargo build --release
+
+FROM crystallang/crystal:0.33.0-alpine
+COPY --from=init-builder /home/rust/src/target/x86_64-unknown-linux-musl/release/library-checker-init /usr/bin

--- a/langs/Dockerfile.RUBY
+++ b/langs/Dockerfile.RUBY
@@ -1,0 +1,6 @@
+FROM ekidd/rust-musl-builder:latest as init-builder
+COPY --chown=rust:rust init .
+RUN cargo build --release
+
+FROM ruby:2.7.1-slim
+COPY --from=init-builder /home/rust/src/target/x86_64-unknown-linux-musl/release/library-checker-init /usr/bin

--- a/langs/Dockerfile.RUBY
+++ b/langs/Dockerfile.RUBY
@@ -2,5 +2,5 @@ FROM ekidd/rust-musl-builder:latest as init-builder
 COPY --chown=rust:rust init .
 RUN cargo build --release
 
-FROM ruby:2.7.1-slim
+FROM ruby:2.7.1-alpine
 COPY --from=init-builder /home/rust/src/target/x86_64-unknown-linux-musl/release/library-checker-init /usr/bin

--- a/langs/build.sh
+++ b/langs/build.sh
@@ -14,5 +14,7 @@ docker build -t library-checker-images-java -f $SCRIPT_DIR/Dockerfile.JAVA $SCRI
 docker build -t library-checker-images-pypy -f $SCRIPT_DIR/Dockerfile.PYPY $SCRIPT_DIR
 docker build -t library-checker-images-golang -f $SCRIPT_DIR/Dockerfile.GOLANG $SCRIPT_DIR
 docker build -t library-checker-images-lisp -f $SCRIPT_DIR/Dockerfile.LISP $SCRIPT_DIR
+docker build -t library-checker-images-crystal -f $SCRIPT_DIR/Dockerfile.CRYSTAL $SCRIPT_DIR
+docker build -t library-checker-images-ruby -f $SCRIPT_DIR/Dockerfile.RUBY $SCRIPT_DIR
 
 docker image prune -f

--- a/langs/langs.toml
+++ b/langs/langs.toml
@@ -123,5 +123,4 @@
     source = "main.rb"
     image_name = "library-checker-images-ruby"
     compile = ["ruby", "-w", "-c", "main.rb"]
-    exec = ["bash", "-c", "'RUBY_THREAD_VM_STACK_SIZE={stack_size:b} ruby main.rb"]
-
+    exec = ["ruby", "main.rb"]

--- a/langs/langs.toml
+++ b/langs/langs.toml
@@ -108,3 +108,20 @@
     image_name = "library-checker-images-lisp"
     compile = ["sbcl", "--noinform", "--eval", "(compile-file \"main.lisp\")", "--quit"]
     exec = ["sbcl", "--control-stack-size", "1GB", "--script", "main.fasl"]
+[[langs]]
+    id = "crystal"
+    name = "Crystal"
+    version = "crystal 0.33.0"
+    source = "main.cr"
+    image_name = "library-checker-images-crystal"
+    compile = ["crystal", "build", "--release", "--no-debug", "--no-color", "-o", "./a.out", "./main.cr"]
+    exec = ["./a.out"]
+[[langs]]
+    id = "ruby"
+    name = "Ruby"
+    version = "ruby 2.7.1"
+    source = "main.rb"
+    image_name = "library-checker-images-ruby"
+    compile = ["ruby", "-w", "-c", "main.rb"]
+    exec = ["bash", "-c", "'RUBY_THREAD_VM_STACK_SIZE={stack_size:b} ruby main.rb"]
+


### PR DESCRIPTION
AtCoderにcrystal言語で参加しているものです。
LibraryCheckerは以前から興味深く伺っており、crystalやrubyが無いことを残念に思っていたのですが、
改めてソースコードを確認させてもらうと、最近、ExecuterのコンテナをDockerベースに変更されて
いたとのこと、手元環境でcrystalとrubyでの動作確認まで実施しましたので、できれば取込お願いします。
