### PR TITLE
実行時間計測方法の変更の提案

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,6 @@
 - Ubuntu 18.04(Judge Server)
 - docker, docker-compose(API, SQL)
 
-### WSLのUbuntuでの動作確認
-WSLのUbuntuで動作確認する際にwindows用のdocker-desktopと連携すると実行時間の計測ができないので下記を実行してUbuntuにdockerをインストールします。
-```sh
-curl -fsSL https://get.docker.com -o get-docker.sh
-sh get-docker.sh
-```
-上記のスクリプトを実行した際に20秒ほど一時停止してdocker-desktopを使用することを推奨されますが、そのまま実行が再開するまで待ってください。
-
 ## API Server
 
 ### 準備


### PR DESCRIPTION
実行時間計測の際にcgroupを読みに行ってタスク一覧を取得する部分をdocker topコマンドでコンテナで実行中のプロセス一覧を取得することで置き換えれば#247 を解消できるのではないかと思って試しに実装してみました。時刻を取得する箇所で置き換え前後のメソッドを両方実行してみて取得結果 >= 2になった回数に差がなかったのでdocker inspectよりは誤差がましではないかと予想していますが、実行する環境によっては全然ダメかもしれないし、とりあえずドラフトでのPRとさせていただきますので一度確認をよろしくお願いします。