### PR TITLE
restrict CPUs for judge service

### DIFF
--- a/packer/judge/judge.service
+++ b/packer/judge/judge.service
@@ -15,6 +15,8 @@ ExecStart = /root/judge \
 -apipass-secret=projects/190778459730/secrets/api-judge-pass/versions/latest \
 -prod
 
+AllowedCPUs=2-3
+
 Restart = always
 Type = simple
 


### PR DESCRIPTION
JudgeのCPUをコンテナのCPU(cpusets=0,1)とかぶらないようにすることで、実行時間が安定する…かも？