### PR TITLE
enable ACL in the default and remove C++14

### DIFF
--- a/judge/judge_test.go
+++ b/judge/judge_test.go
@@ -118,7 +118,7 @@ func TestCppAplusBAC(t *testing.T) {
 	testAplusBAC(t, "cpp", "ac.cpp")
 }
 func TestCppAclAplusBAC(t *testing.T) {
-	testAplusBAC(t, "cpp-acl", "ac_acl.cpp")
+	testAplusBAC(t, "cpp", "ac_acl.cpp")
 }
 func TestRustAplusBAC(t *testing.T) {
 	testAplusBAC(t, "rust", "ac.rs")

--- a/langs/langs.toml
+++ b/langs/langs.toml
@@ -7,7 +7,7 @@
 [[langs]]
     id = "cpp-func"
     name = "C++23(Function)"
-    version = "g++(14.1) + ac-library 1.5.1"
+    version = "g++(14.1) + AC Library(1.5.1)"
     source = "main.cpp"    
     image_name = "library-checker-images-gcc"
     compile = ["g++", "-O2", "-std=c++23", "-DEVAL", "-march=native", "-o", "main", "grader.cpp", "main.cpp", "-I", "/opt/ac-library"]
@@ -16,7 +16,7 @@
 [[langs]]
     id = "cpp"
     name = "C++23"
-    version = "g++(14.1)"
+    version = "g++(14.1) + AC Library(1.5.1)"
     source = "main.cpp"    
     image_name = "library-checker-images-gcc"
     compile = ["g++", "-O2", "-std=c++23", "-DEVAL", "-march=native", "-o", "main", "main.cpp", "-I", "/opt/ac-library"]
@@ -24,34 +24,18 @@
 [[langs]]
     id = "cpp20"
     name = "C++20"
-    version = "g++(14.1)"
+    version = "g++(14.1) + AC Library(1.5.1)"
     source = "main.cpp"
-    image_name = "library-checker-images-gcc"
-    compile = ["g++", "-O2", "-std=c++20", "-DEVAL", "-march=native", "-o", "main", "main.cpp"]
-    exec = ["./main"]
-[[langs]]
-    id = "cpp-acl"
-    name = "C++20(ACL)"
-    version = "g++(14.1) + ac-library 1.5.1"
-    source = "main.cpp"    
     image_name = "library-checker-images-gcc"
     compile = ["g++", "-O2", "-std=c++20", "-DEVAL", "-march=native", "-o", "main", "main.cpp", "-I", "/opt/ac-library"]
     exec = ["./main"]
 [[langs]]
     id = "cpp17"
     name = "C++17"
-    version = "g++(14.1)"
+    version = "g++(14.1) + AC Library(1.5.1)"
     source = "main.cpp"    
     image_name = "library-checker-images-gcc"
-    compile = ["g++", "-O2", "-std=c++17", "-DEVAL", "-march=native", "-o", "main", "main.cpp"]
-    exec = ["./main"]
-[[langs]]
-    id = "cpp14"
-    name = "C++14"
-    version = "g++(14.1)"
-    source = "main.cpp"
-    image_name = "library-checker-images-gcc"
-    compile = ["g++", "-O2", "-std=c++14", "-DEVAL", "-march=native", "-o", "main", "main.cpp"]
+    compile = ["g++", "-O2", "-std=c++17", "-DEVAL", "-march=native", "-o", "main", "main.cpp", "-I", "/opt/ac-library"]
     exec = ["./main"]
 [[langs]]
     id = "rust"


### PR DESCRIPTION
特に言語選定に明確な基準はないが、ふんわりとAtCoderに合わせて

- ACLをデフォルトで有効化
- C++14を削除