### PR TITLE
Separate database CI from api-test workflow

### DIFF
--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -26,11 +26,6 @@ jobs:
     #     version: latest
     #     working-directory: ./api
 
-    # - name: golangci-lint (database)
-    #   uses: golangci/golangci-lint-action@v8
-    #   with:
-    #     version: latest
-    #     working-directory: ./database
 
     # - name: golangci-lint (storage)
     #   uses: golangci/golangci-lint-action@v8
@@ -52,9 +47,6 @@ jobs:
       run: go test .
       working-directory: ./uploader
 
-    - name: Database module test
-      run: go test .
-      working-directory: ./database
 
     - name: Storage module test
       run: go test .

--- a/.github/workflows/database-test.yml
+++ b/.github/workflows/database-test.yml
@@ -1,0 +1,33 @@
+name: Database-Test
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'database/**'
+      - '.github/workflows/database-test.yml'
+  pull_request:
+    paths:
+      - 'database/**'
+      - '.github/workflows/database-test.yml'
+
+jobs:
+  database-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.21'
+
+    - id: run-docker-compose
+      name: Run docker compose
+      run: docker compose up -d --build --wait
+
+    - name: Database module test
+      run: go test . -v
+      working-directory: ./database

--- a/.github/workflows/database-test.yml
+++ b/.github/workflows/database-test.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - run: ./run_protoc.sh
+
     - name: Set up Go
       uses: actions/setup-go@v4
       with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,12 +42,12 @@ jobs:
         version: latest
         working-directory: ./database
 
-    # - name: golangci-lint (api)
-    #   if: steps.changes.outputs.api == 'true'
-    #   uses: golangci/golangci-lint-action@v3
-    #   with:
-    #     version: latest
-    #     working-directory: ./api
+    - name: golangci-lint (api)
+      if: steps.changes.outputs.api == 'true'
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: latest
+        working-directory: ./api
 
     # - name: golangci-lint (storage)
     #   if: steps.changes.outputs.storage == 'true'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,76 @@
+name: Lint
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'database/**'
+      - 'api/**'
+      - 'storage/**'
+      - 'uploader/**'
+      - 'judge/**'
+  pull_request:
+    paths:
+      - 'database/**'
+      - 'api/**'
+      - 'storage/**'
+      - 'uploader/**'
+      - 'judge/**'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Detect changed files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          database:
+            - 'database/**'
+          api:
+            - 'api/**'
+          storage:
+            - 'storage/**'
+          uploader:
+            - 'uploader/**'
+          judge:
+            - 'judge/**'
+
+    - run: ./run_protoc.sh
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.21'
+
+    - name: golangci-lint (database)
+      if: steps.changes.outputs.database == 'true'
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: latest
+        working-directory: ./database
+
+    # - name: golangci-lint (api)
+    #   if: steps.changes.outputs.api == 'true'
+    #   uses: golangci/golangci-lint-action@v3
+    #   with:
+    #     version: latest
+    #     working-directory: ./api
+
+    # - name: golangci-lint (storage)
+    #   if: steps.changes.outputs.storage == 'true'
+    #   uses: golangci/golangci-lint-action@v3
+    #   with:
+    #     version: latest
+    #     working-directory: ./storage
+
+    # - name: golangci-lint (uploader)
+    #   if: steps.changes.outputs.uploader == 'true'
+    #   uses: golangci/golangci-lint-action@v3
+    #   with:
+    #     version: latest
+    #     working-directory: ./uploader

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,19 +47,19 @@ jobs:
         version: latest
         working-directory: ./database
 
-    - name: golangci-lint (api)
-      if: steps.changes.outputs.api == 'true'
-      uses: golangci/golangci-lint-action@v8
-      with:
-        version: latest
-        working-directory: ./api
+    # - name: golangci-lint (api)
+    #   if: steps.changes.outputs.api == 'true'
+    #   uses: golangci/golangci-lint-action@v8
+    #   with:
+    #     version: latest
+    #     working-directory: ./api
 
-    - name: golangci-lint (storage)
-      if: steps.changes.outputs.storage == 'true'
-      uses: golangci/golangci-lint-action@v8
-      with:
-        version: latest
-        working-directory: ./storage
+    # - name: golangci-lint (storage)
+    #   if: steps.changes.outputs.storage == 'true'
+    #   uses: golangci/golangci-lint-action@v8
+    #   with:
+    #     version: latest
+    #     working-directory: ./storage
 
     # - name: golangci-lint (uploader)
     #   if: steps.changes.outputs.uploader == 'true'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,12 +54,12 @@ jobs:
         version: latest
         working-directory: ./api
 
-    # - name: golangci-lint (storage)
-    #   if: steps.changes.outputs.storage == 'true'
-    #   uses: golangci/golangci-lint-action@v3
-    #   with:
-    #     version: latest
-    #     working-directory: ./storage
+    - name: golangci-lint (storage)
+      if: steps.changes.outputs.storage == 'true'
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: latest
+        working-directory: ./storage
 
     # - name: golangci-lint (uploader)
     #   if: steps.changes.outputs.uploader == 'true'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,19 +4,7 @@ on:
   push:
     branches:
       - master
-    paths:
-      - 'database/**'
-      - 'api/**'
-      - 'storage/**'
-      - 'uploader/**'
-      - 'judge/**'
   pull_request:
-    paths:
-      - 'database/**'
-      - 'api/**'
-      - 'storage/**'
-      - 'uploader/**'
-      - 'judge/**'
 
 jobs:
   lint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,21 +42,21 @@ jobs:
 
     - name: golangci-lint (database)
       if: steps.changes.outputs.database == 'true'
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@v8
       with:
         version: latest
         working-directory: ./database
 
     - name: golangci-lint (api)
       if: steps.changes.outputs.api == 'true'
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@v8
       with:
         version: latest
         working-directory: ./api
 
     - name: golangci-lint (storage)
       if: steps.changes.outputs.storage == 'true'
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@v8
       with:
         version: latest
         working-directory: ./storage

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,14 +19,19 @@ jobs:
         filters: |
           database:
             - 'database/**'
+            - '.github/workflows/lint.yml'
           api:
             - 'api/**'
+            - '.github/workflows/lint.yml'
           storage:
             - 'storage/**'
+            - '.github/workflows/lint.yml'
           uploader:
             - 'uploader/**'
+            - '.github/workflows/lint.yml'
           judge:
             - 'judge/**'
+            - '.github/workflows/lint.yml'
 
     - run: ./run_protoc.sh
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,71 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'database/**'
+      - 'api/**'
+      - 'storage/**'
+      - 'uploader/**'
+      - 'judge/**'
+  pull_request:
+    paths:
+      - 'database/**'
+      - 'api/**'
+      - 'storage/**'
+      - 'uploader/**'
+      - 'judge/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Detect changed files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          database:
+            - 'database/**'
+          api:
+            - 'api/**'
+          storage:
+            - 'storage/**'
+          uploader:
+            - 'uploader/**'
+          judge:
+            - 'judge/**'
+
+    - run: ./run_protoc.sh
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.21'
+
+    - name: Run docker compose
+      run: docker compose up -d --build --wait
+
+    - name: Database module test
+      if: steps.changes.outputs.database == 'true'
+      run: go test . -v
+      working-directory: ./database
+
+    - name: API module test
+      if: steps.changes.outputs.api == 'true'
+      run: go test . -v
+      working-directory: ./api
+
+    - name: Storage module test
+      if: steps.changes.outputs.storage == 'true'
+      run: go test . -v
+      working-directory: ./storage
+
+    - name: Uploader module test
+      if: steps.changes.outputs.uploader == 'true'
+      run: go test . -v
+      working-directory: ./uploader

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,14 +19,19 @@ jobs:
         filters: |
           database:
             - 'database/**'
+            - '.github/workflows/test.yml'
           api:
             - 'api/**'
+            - '.github/workflows/test.yml'
           storage:
             - 'storage/**'
+            - '.github/workflows/test.yml'
           uploader:
             - 'uploader/**'
+            - '.github/workflows/test.yml'
           judge:
             - 'judge/**'
+            - '.github/workflows/test.yml'
 
     - run: ./run_protoc.sh
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,19 +4,7 @@ on:
   push:
     branches:
       - master
-    paths:
-      - 'database/**'
-      - 'api/**'
-      - 'storage/**'
-      - 'uploader/**'
-      - 'judge/**'
   pull_request:
-    paths:
-      - 'database/**'
-      - 'api/**'
-      - 'storage/**'
-      - 'uploader/**'
-      - 'judge/**'
 
 jobs:
   test:

--- a/database/hack.go
+++ b/database/hack.go
@@ -96,13 +96,14 @@ func FetchHackList(db *gorm.DB, skip, limit int, user, status, order string) ([]
 	if order == "" {
 		order = "-id"
 	}
-	if order == "-id" {
+	switch order {
+	case "-id":
 		query = query.Order("id DESC")
-	} else if order == "id" {
+	case "id":
 		query = query.Order("id ASC")
-	} else if order == "time" {
+	case "time":
 		query = query.Order("hack_time ASC")
-	} else if order == "-time" {
+	case "-time":
 		query = query.Order("hack_time DESC")
 	}
 	


### PR DESCRIPTION
## Summary
- Create dedicated `database-test.yml` workflow with path-based triggers for `database/` directory
- Remove database testing from `api-test.yml` to avoid duplication and improve CI efficiency
- Database CI now only runs when database-related files change

## Test plan
- [ ] Verify database-test.yml triggers on database/ changes
- [ ] Confirm api-test.yml no longer includes database tests
- [ ] Test that both workflows run independently

🤖 Generated with [Claude Code](https://claude.ai/code)