### PR TITLE
Fix api-deploy.yml protoc script reference

### DIFF
--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -54,7 +54,7 @@ jobs:
         username: oauth2accesstoken
         password: ${{ steps.auth.outputs.access_token }}
 
-    - run: ./gen_protoc.sh
+    - run: ./run_protoc.sh
 
     - uses: docker/metadata-action@v4
       id: meta


### PR DESCRIPTION
## Summary
- Fix api-deploy.yml to use `run_protoc.sh` instead of `gen_protoc.sh`
- The deploy workflow was referencing a non-existent script causing deployment failures

## Test plan
- [ ] Verify api-deploy workflow runs successfully
- [ ] Confirm protoc generation works correctly during deployment
- [ ] Check that the correct script `run_protoc.sh` exists in the repository

🤖 Generated with [Claude Code](https://claude.ai/code)