### PR TITLE
Optimize CI performance by separating Docker-heavy tests

### DIFF
--- a/.github/workflows/judge-test.yml
+++ b/.github/workflows/judge-test.yml
@@ -1,0 +1,79 @@
+name: Judge Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  judge-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Detect changed files
+      uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          judge:
+            - 'judge/**'
+            - 'langs/**'  # judge depends on langs
+            - 'executor/**'  # judge depends on executor
+            - '.github/workflows/judge-test.yml'
+          executor:
+            - 'executor/**'
+            - '.github/workflows/judge-test.yml'
+
+    - run: ./run_protoc.sh
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.21'
+
+    - name: Run docker compose
+      if: steps.changes.outputs.judge == 'true' || steps.changes.outputs.executor == 'true'
+      run: docker compose up -d --build --wait
+
+    - name: Install crun
+      if: steps.changes.outputs.judge == 'true' || steps.changes.outputs.executor == 'true'
+      run: sudo ./packer/base/crun-install.sh
+
+    - name: Prepare docker config
+      if: steps.changes.outputs.judge == 'true' || steps.changes.outputs.executor == 'true'
+      run: sudo cp ./packer/base/docker-daemon.json /etc/docker/daemon.json
+
+    - name: Restart docker
+      if: steps.changes.outputs.judge == 'true' || steps.changes.outputs.executor == 'true'
+      run: sudo service docker restart
+          
+    - name: Build lang images
+      if: steps.changes.outputs.judge == 'true' || steps.changes.outputs.executor == 'true'
+      run: ./build.sh
+      working-directory: ./langs
+
+    - name: Judge module test
+      if: steps.changes.outputs.judge == 'true'
+      run: go test -v .
+      working-directory: ./judge
+
+    - name: Executor module test
+      if: steps.changes.outputs.executor == 'true'
+      run: go test -v .
+      working-directory: ./executor
+
+    - name: golangci-lint (judge)
+      if: steps.changes.outputs.judge == 'true'
+      uses: golangci/golangci-lint-action@v8
+      with:
+        version: latest
+        working-directory: ./judge
+
+    - name: golangci-lint (executor)
+      if: steps.changes.outputs.executor == 'true'
+      uses: golangci/golangci-lint-action@v8
+      with:
+        version: latest
+        working-directory: ./executor

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,15 +29,8 @@ jobs:
           uploader:
             - 'uploader/**'
             - '.github/workflows/lint.yml'
-          judge:
-            - 'judge/**'
-            - 'langs/**'  # judge depends on langs
-            - '.github/workflows/lint.yml'
           langs:
             - 'langs/**'
-            - '.github/workflows/lint.yml'
-          executor:
-            - 'executor/**'
             - '.github/workflows/lint.yml'
 
     - run: ./run_protoc.sh
@@ -75,23 +68,9 @@ jobs:
         version: latest
         working-directory: ./uploader
 
-    - name: golangci-lint (judge)
-      if: steps.changes.outputs.judge == 'true'
-      uses: golangci/golangci-lint-action@v8
-      with:
-        version: latest
-        working-directory: ./judge
-
     - name: golangci-lint (langs)
       if: steps.changes.outputs.langs == 'true'
       uses: golangci/golangci-lint-action@v8
       with:
         version: latest
         working-directory: ./langs
-
-    - name: golangci-lint (executor)
-      if: steps.changes.outputs.executor == 'true'
-      uses: golangci/golangci-lint-action@v8
-      with:
-        version: latest
-        working-directory: ./executor

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,15 +29,8 @@ jobs:
           uploader:
             - 'uploader/**'
             - '.github/workflows/test.yml'
-          judge:
-            - 'judge/**'
-            - 'langs/**'  # judge depends on langs
-            - '.github/workflows/test.yml'
           langs:
             - 'langs/**'
-            - '.github/workflows/test.yml'
-          executor:
-            - 'executor/**'
             - '.github/workflows/test.yml'
 
     - run: ./run_protoc.sh
@@ -70,34 +63,7 @@ jobs:
       run: go test . -v
       working-directory: ./uploader
 
-    - name: Install crun
-      if: steps.changes.outputs.judge == 'true' || steps.changes.outputs.langs == 'true' || steps.changes.outputs.executor == 'true'
-      run: sudo ./packer/base/crun-install.sh
-
-    - name: Prepare docker config
-      if: steps.changes.outputs.judge == 'true' || steps.changes.outputs.langs == 'true' || steps.changes.outputs.executor == 'true'
-      run: sudo cp ./packer/base/docker-daemon.json /etc/docker/daemon.json
-
-    - name: Restart docker
-      if: steps.changes.outputs.judge == 'true' || steps.changes.outputs.langs == 'true' || steps.changes.outputs.executor == 'true'
-      run: sudo service docker restart
-          
-    - name: Build lang images
-      if: steps.changes.outputs.judge == 'true' || steps.changes.outputs.langs == 'true' || steps.changes.outputs.executor == 'true'
-      run: ./build.sh
-      working-directory: ./langs
-
-    - name: Judge module test
-      if: steps.changes.outputs.judge == 'true'
-      run: go test -v .
-      working-directory: ./judge
-
     - name: Langs module test
       if: steps.changes.outputs.langs == 'true'
       run: go test -v .
       working-directory: ./langs
-
-    - name: Executor module test
-      if: steps.changes.outputs.executor == 'true'
-      run: go test -v .
-      working-directory: ./executor


### PR DESCRIPTION
## Summary
- Separate CI workflows to solve Docker build performance issues
- Create dedicated `judge-test.yml` for executor and judge module tests
- Optimize main `test.yml` to handle only lightweight modules

## Changes
- **New workflow**: `judge-test.yml` handles Docker-heavy tests (executor/judge modules)
- **Updated**: `test.yml` removes Docker build steps, focuses on lightweight tests  
- **Updated**: `lint.yml` removes judge/executor linting (moved to judge-test.yml)

## Performance Impact
- Significantly reduces CI time when only lightweight modules are changed
- Docker builds only run when executor/judge modules are modified
- Parallel execution of lightweight vs Docker-heavy tests

🤖 Generated with [Claude Code](https://claude.ai/code)