### PR TITLE
Fix test case display order to follow info.toml order

### DIFF
--- a/api/submission.go
+++ b/api/submission.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"log"
-	"sort"
 	"time"
 
 	pb "github.com/yosupo06/library-checker-judge/api/proto"
@@ -125,9 +124,7 @@ func (s *server) SubmissionInfo(ctx context.Context, in *pb.SubmissionInfoReques
 		CanRejudge:   rej,
 	}
 
-	sort.Slice(cases, func(i, j int) bool {
-		return cases[i].Testcase < cases[j].Testcase
-	})
+	// Cases are already sorted by DisplayOrder in FetchTestcaseResults
 
 	for _, c := range cases {
 		res.CaseResults = append(res.CaseResults, &pb.SubmissionCaseResult{

--- a/judge/submission.go
+++ b/judge/submission.go
@@ -85,6 +85,7 @@ func (data *SubmissionTaskData) init() error {
 		data.results[i].Submission = data.s.ID
 		data.results[i].Testcase = testCases[i]
 		data.results[i].Status = "-"
+		data.results[i].DisplayOrder = int32(i)
 	}
 
 	data.s.MaxTime = -1


### PR DESCRIPTION
## Summary
- Fixes test case display order on frontend submissions page to follow info.toml order instead of lexicographical order
- Sets DisplayOrder field when saving test case results in judge module
- Removes unnecessary lexicographical sorting in API submission endpoint

## Changes
- **judge/submission.go**: Set `DisplayOrder = int32(i)` when initializing test case results to preserve info.toml order
- **api/submission.go**: Remove lexicographical sorting since cases are already sorted by DisplayOrder in database layer

## Behavior
- **New submissions**: Test cases display in info.toml order (example → random → max_random → path)  
- **Old submissions**: May have different order but no program crashes (DisplayOrder defaults to 0)

## Test plan
- [x] Code compiles without errors
- [x] Passes golangci-lint checks
- [ ] Test with new submission to verify correct order
- [ ] Verify old submissions still display without errors

🤖 Generated with [Claude Code](https://claude.ai/code)