### PR TITLE
Phase 1: dual-write to v4 (testcase/examples/files) + OverallVersion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ deploy/library_checker_pb2.py
 deploy/library_checker_pb2_grpc.py
 
 go.work
+uploader/uploader

--- a/database/problem.go
+++ b/database/problem.go
@@ -9,13 +9,13 @@ import (
 
 // Problem is db table
 type Problem struct {
-    Name             string `gorm:"primaryKey"`
-    Title            string
-    SourceUrl        string
-    Timelimit        int32
-    TestCasesVersion string
-    Version          string
-    OverallVersion   string
+	Name             string `gorm:"primaryKey"`
+	Title            string
+	SourceUrl        string
+	Timelimit        int32
+	TestCasesVersion string
+	Version          string
+	OverallVersion   string
 }
 
 func FetchProblem(db *gorm.DB, name string) (Problem, error) {

--- a/database/problem.go
+++ b/database/problem.go
@@ -9,12 +9,13 @@ import (
 
 // Problem is db table
 type Problem struct {
-	Name             string `gorm:"primaryKey"`
-	Title            string
-	SourceUrl        string
-	Timelimit        int32
-	TestCasesVersion string
-	Version          string
+    Name             string `gorm:"primaryKey"`
+    Title            string
+    SourceUrl        string
+    Timelimit        int32
+    TestCasesVersion string
+    Version          string
+    OverallVersion   string
 }
 
 func FetchProblem(db *gorm.DB, name string) (Problem, error) {

--- a/docs/bucket-structure.md
+++ b/docs/bucket-structure.md
@@ -1,77 +1,117 @@
 # バケット構成とファイル
 
-- 目的: Public と Private の各ファイル、バケット構成、オブジェクトキーの現状を整理する。
+- 目的: Public / Private バケットの構成と、各オブジェクトキーの仕様を整理する。
 
 **バケット**
 - Private バケット: `MINIO_BUCKET`（デフォルト `testcase`）— テストケースの tarball（非公開オブジェクト）を格納。
 - Public バケット: `MINIO_PUBLIC_BUCKET`（デフォルト `testcase-public`）— 公開ファイルと例題 I/O を格納。
 
 **オブジェクトキー構造（Object Keys）**
-- Private（テストケース tarball）: `v3/{problem}/testcase/{testcase_hash}.tar.gz`
-- Public（例題 I/O）:
-  - 入力: `v3/{problem}/testcase/{testcase_hash}/in/example_*.in`
-  - 出力: `v3/{problem}/testcase/{testcase_hash}/out/example_*.out`
-- Public（バージョンごとの公開ファイル）: `v3/{problem}/files/{version}/{path}`
+- 現行（v3 運用 — 利用側の参照は当面こちら）
+  - Private（テストケース tarball）: `v3/{problem}/testcase/{testcase_hash}.tar.gz`
+  - Public（例題 I/O）:
+    - 入力: `v3/{problem}/testcase/{testcase_hash}/in/example_*.in`
+    - 出力: `v3/{problem}/testcase/{testcase_hash}/out/example_*.out`
+  - Public（公開ファイル — 問題バージョン依存）: `v3/{problem}/files/{version}/{path}`
 
-例（problem: `aplusb`, version: `v`, testcase hash: `h`）:
-- Tarball: `v3/aplusb/testcase/h.tar.gz`
-- 例題入力: `v3/aplusb/testcase/h/in/example_00.in`
-- 例題出力: `v3/aplusb/testcase/h/out/example_00.out`
-- 公開ファイル: `v3/aplusb/files/v/task.md`
+- 新スキーマ（v4 仕様 — Phase 1 で並列に全て用意）
+  - Private（テストケース tarball）: `v4/testcase/{problem}/{testcase_hash}.tar.gz`
+  - Public（例題 I/O）:
+    - 入力: `v4/examples/{problem}/{testcase_hash}/in/example_*.in`
+    - 出力: `v4/examples/{problem}/{testcase_hash}/out/example_*.out`
+  - Public（公開ファイル — 問題バージョン依存; v4 は `Version -> OverallVersion` を用いる）:
+    - `v4/files/{problem}/{overall_version}/common/...` — リポジトリルート `common/` の中身
+    - `v4/files/{problem}/{overall_version}/{problem_name}/...` — 問題ディレクトリ全体
 
-**Private バケットの内容**
-- オブジェクト:
-  - テストケース tarball のみ: `v3/{problem}/testcase/{testcase_hash}.tar.gz`
-- 備考:
-  - 非公開なのは tarball のみ。個々のテストケースファイルは非公開ではアップされず、例題 I/O のみが Public バケットに重複配置される。
-  - アップロード条件: テストケースハッシュの変更、または `-force` 指定時。
-  - 利用者: ジャッジが提出ごとにこの tarball をダウンロードして展開。
+**例（problem: `aplusb`, version: `v`, testcase hash: `h`）**
+- v3（現行参照）
+  - Private tarball: `v3/aplusb/testcase/h.tar.gz`
+  - 例題入力: `v3/aplusb/testcase/h/in/example_00.in`
+  - 例題出力: `v3/aplusb/testcase/h/out/example_00.out`
+  - 公開ファイル: `v3/aplusb/files/v/task.md` 等
+- v4（Phase 1 で並列に作成）
+  - Private tarball: `v4/testcase/aplusb/h.tar.gz`
+  - 例題入力: `v4/examples/aplusb/h/in/example_00.in`
+  - 例題出力: `v4/examples/aplusb/h/out/example_00.out`
+  - 公開ファイル（OverallVersion = ov）:
+    - `v4/files/aplusb/ov/common/fastio.h`
+    - `v4/files/aplusb/ov/aplusb/task.md`
 
-**公開ファイルとしてアップロードされるもの（Public バケット）**
-- リポジトリルート `common/`（必須）:
-  - `common/fastio.h`
-  - `common/random.h`
-  - `common/testlib.h`
-- 問題ディレクトリ（必須）:
-  - `task.md`
-  - `info.toml`
-  - `checker.cpp`
-  - `verifier.cpp`
-  - `params.h`
-  - `sol/correct.cpp`
-- 問題ディレクトリ（任意・存在すればアップロード）:
-  - `grader/grader.cpp`
-  - `grader/solve.hpp`
+**Private バケット**
+- 非公開。ジャッジサーバーのみがアクセス。
+- ジャッジは提出の評価時に tarball をダウンロード・展開し、ローカルにキャッシュして再ダウンロードを回避する。
 
-これらはキー接頭辞 `v3/{problem}/files/{version}/...` の下に配置される。
-
-**アップロードのタイミング**
-- テストケース（Private バケット）:
-  - トリガ: テストケースバージョン（ハッシュ）が変化、または `-force`。
-  - 動作: `v3/{problem}/testcase/{hash}.tar.gz` に tar.gz をアップロード。
-  - 併せて: 例題 `.in/.out` を個別に Public バケットの testcase キー配下へアップロード。
-- 公開ファイル（Public バケット）:
-  - トリガ: 問題バージョンが変化、または `-force`。
-  - 動作: 上記の公開ファイル一式を `v3/{problem}/files/{version}/...` にアップロード。
+**Public バケット**
+- 公開。誰でも参照可能。
+- Phase 1 中の運用: 参照は引き続き v3 を利用しつつ、v4 の全構造（examples/files）を並行で作成・維持する。
 
 **バージョンとハッシュの定義**
-- テストケースバージョン（`TestCaseVersion`）: 問題ディレクトリ内の `hash.json` に基づく（各テストケースファイルのハッシュを結合）。
-- 問題バージョン（`Version`）: 以下の内容をハッシュ化:
-  - `TestCaseVersion`
-  - 公開ファイル集合に含まれる全エントリの内容（必須は存在必須・任意は存在するもののみ。任意ファイルの欠如は計算を阻害しない）。
+- テストケースバージョン（`TestCaseVersion`）:
+  - 問題ディレクトリ内の `hash.json` を集約（各テストケースファイルのハッシュを結合）して算出。
+  - 提出の再ジャッジ判定に利用（保守的）。
+- 問題バージョン（v3: `Version` / v4: `OverallVersion`）:
+  - 以下の内容をハッシュ化して算出。
+    - `TestCaseVersion`
+    - v3: 公開ファイル集合の固定リスト（互換）
+    - v4: Git で追跡されている `common/` と `{problem_name}/` 配下の全ファイルの内容（untracked は除外）
+  - 軽量な公開ファイル群のみの再アップロードで済むため、更新運用は容易。
 
-**Downloader のローカル配置（参考）**
-- テストケース展開先: `<tmp>/{testcase_hash}/in|out/...`（Private バケットの tar.gz から展開）。
-- 公開ファイル展開先: `<tmp>/{version}/...`（`v3/{problem}/files/{version}/...` の末尾構造をミラー）。
-- アクセスヘルパ:
-  - `PublicFilePath(key)` -> `<tmp>/{version}/{key}`
-  - 例: `verifier.cpp`, `checker.cpp`, `sol/correct.cpp`, `params.h`, `common/*.h`, `task.md`, `info.toml`。
+**アップロードのタイミング**
+- `TestCaseVersion` または `Version / OverallVersion` が変化した場合のみアップロード（高速化のため）。
+- 変化検知はデータベースに保存されたバージョンとの比較で行う。
+- Phase 1 実施内容（v3 運用は維持しつつ v4 にも並列アップロード）:
+  - Private: `v3/{problem}/testcase/{hash}.tar.gz` と `v4/testcase/{problem}/{hash}.tar.gz` の両方にアップロード。
+  - Public（例題 I/O）: `v3/{problem}/testcase/{hash}/{in,out}/...` と `v4/examples/{problem}/{hash}/{in,out}/...` の両方にアップロード。
+  - Public（公開ファイル）: `v3/{problem}/files/{version}/...`（従来の Version）と `v4/files/{problem}/{overall_version}/...`（新 OverallVersion）の両方にアップロード。
+
+**将来（最終 v4 仕様の方向性）**
+- 例題 I/O: `v4/examples/{problem}/{testcase_hash}/{in,out}/example_*`
+- 公開ファイル: `v4/files/{problem}/{overall_version}/common/...` および `v4/files/{problem}/{overall_version}/{problem_name}/...`
 
 **関連コード**
-- アップローダ本体: `uploader/main.go`
-- 公開ファイル選定とアップロード: `storage/upload.go`（`fileInfos`, `UploadPublicFiles`）
-- キー生成: `storage/problem.go`（`publicFileKeyPrefix`, `publicFileKey`, `publicTestCaseKey`）
-- Private tarball のアップロード: `storage/problem.go`（`UploadTestCases`, `testCasesKey`）
-- ジャッジによる tarball ダウンロード: `storage/download.go`（`fetchTestCases`）
-- バケットと環境変数: `storage/client.go`（`MINIO_BUCKET`, `MINIO_PUBLIC_BUCKET`）
-- Downloader の挙動: `storage/download.go`
+- アップローダー本体: `uploader/main.go`
+- ストレージ（キー生成・アップロード処理）: `storage/*`
+  - `storage/problem.go` — キー生成（v4 仕様へ更新予定）
+  - `storage/upload.go` — 公開ファイルの収集とアップロード（`common/` + 問題ディレクトリ全体）
+  - `storage/download.go` — ジャッジ側のダウンロード処理（v4 仕様へ更新予定）
+- 問題リポジトリ: `library-checker-problems`（例: `sample/aplusb`）
+
+## 移行プラン（v3 → v4）
+
+目的
+- Phase 1 で v4 の全構造（private tarball / examples / files）を一気に整備し、以後も v3 と並列でアップロード維持。
+- 利用側（Judge/Frontend）は当面 v3 を参照し、十分な検証後に v4 へ切替。
+- DB では v3 の `Version` は従来どおり保持し、v4 用に新たに `OverallVersion` を別フィールドで保持。
+
+フェーズ概要
+1) Phase 1（並列化・完全 v4 構築）
+   - 目的: v3 のアップロードを維持しつつ、同時に v4（testcase/examples/files）にも全て書き込む「デュアルライティング」を実現。
+   - アップローダ変更:
+     - バージョン計算を二系統に分離: `Version`（現行の対象）と `OverallVersion`（`common/` + `{problem_name}/` 全ファイル）。
+     - Private: 生成した tarball を v3 と v4 の両方へアップロード。
+     - Public 例題: v3 と v4（`v4/examples/...`）の両方へアップロード（再生成コストが高い場合は v3→v4 のサーバーサイドコピーでも可）。
+     - Public 公開ファイル: v3（`files/{Version}`）と v4（`files/{OverallVersion}`）の両方へアップロード。
+   - DB 変更:
+     - `problems` テーブルに `overall_version`（文字列）を追加（NULL/空文字許容）。
+     - 当面 `testcases_version` は共通（v3/v4 で同一）。
+   - 運用:
+     - 夜間に `--force` で全問題を再生成・再アップロード（Private v4 tarball を作るため）。
+     - 以後は通常の差分アップロード時に v3/v4 並行更新。
+
+2) Phase 2（参照側の切替準備とフォールバック）
+   - Judge/Frontend に v4 参照機能を追加（初期は OFF）。
+   - 切替時は v4 を優先参照、v4 不在時のみ v3 へフォールバック（短期間）。
+
+3) Phase 3（クリーンアップ）
+   - 安定後に v3 Public を段階整理。Private v3 tarball は運用方針に応じて整理。
+
+実装メモ/注意
+- バージョン定義:
+  - `Version`: 現行の選定ルール（従来の固定ファイル群）。
+  - `OverallVersion`: `common/` 配下と `{problem_name}/` 配下の全ファイルをハッシュ化して算出。
+- サーバーサイドコピー（例題 I/O の使い回し向け）:
+  - MinIO: `mc cp -r my/public/v3/{problem}/testcase/{hash}/ my/public/v4/examples/{problem}/{hash}/`
+  - GCS: `gsutil -m cp -r gs://<bucket>/v3/{problem}/testcase/{hash}/ gs://<bucket>/v4/examples/{problem}/{hash}/`
+- 冪等性: 上書き許容。存在チェックでスキップしても良い。
+- キャッシュ: 切替直前に v4 へ全ファイル反映→必要なら `v4/meta/{problem}.json` を最後に更新して原子的に切替（任意）。
+- アクセス制御: Public バケットのポリシーは v4 パスにも適用されることを事前確認。

--- a/storage/problem.go
+++ b/storage/problem.go
@@ -95,9 +95,7 @@ func (p Problem) v4ExamplesKey(key string) string {
 func (p Problem) v4FilesCommonKey(key string) string {
 	// key is like "common/xxx" or just file under common. We accept both.
 	commonPath := key
-	if strings.HasPrefix(commonPath, "common/") {
-		commonPath = strings.TrimPrefix(commonPath, "common/")
-	}
+	commonPath = strings.TrimPrefix(commonPath, "common/")
 	return fmt.Sprintf("v4/files/%s/%s/common/%s", p.Name, p.OverallVersion, commonPath)
 }
 
@@ -106,13 +104,7 @@ func (p Problem) v4FilesProblemKey(rel string) string {
 	return fmt.Sprintf("v4/files/%s/%s/%s/%s", p.Name, p.OverallVersion, p.Name, rel)
 }
 
-// publicCommonV4Key returns the v4 path for common/* files only.
-// v4/files/{problem}/{overall_version}/common/{path_under_common}
-func (p Problem) publicCommonV4Key(key string) string {
-	// key is expected like "common/fastio.h"
-	trimmed := strings.TrimPrefix(key, "common/")
-	return fmt.Sprintf("v4/files/%s/%s/common/%s", p.Name, p.OverallVersion, trimmed)
-}
+// Note: publicCommonV4Key removed as unused (use v4FilesCommonKey instead).
 
 type Info struct {
 	Title     string

--- a/storage/problem.go
+++ b/storage/problem.go
@@ -11,26 +11,48 @@ import (
 )
 
 type Problem struct {
-	Name            string
-	Version         string
-	TestCaseVersion string
+    Name            string
+    Version         string
+    OverallVersion  string
+    TestCaseVersion string
 }
 
 func (p Problem) UploadTestCases(ctx context.Context, c Client, tarGzPath string) error {
-	remoteURL := p.testCasesKey()
-	slog.Info("Upload test cases", "remote", remoteURL)
-	if _, err := c.client.FPutObject(ctx, c.bucket, remoteURL, tarGzPath, minio.PutObjectOptions{}); err != nil {
-		return err
-	}
-	return nil
+    remoteURL := p.testCasesKey()
+    slog.Info("Upload test cases", "remote", remoteURL)
+    if _, err := c.client.FPutObject(ctx, c.bucket, remoteURL, tarGzPath, minio.PutObjectOptions{}); err != nil {
+        return err
+    }
+    return nil
+}
+
+// UploadTestCasesV4 uploads testcases tarball also to v4 private path for Phase 1 dual-write.
+func (p Problem) UploadTestCasesV4(ctx context.Context, c Client, tarGzPath string) error {
+    remoteURL := p.v4TestCasesKey()
+    slog.Info("Upload test cases (v4)", "remote", remoteURL)
+    if _, err := c.client.FPutObject(ctx, c.bucket, remoteURL, tarGzPath, minio.PutObjectOptions{}); err != nil {
+        return err
+    }
+    return nil
 }
 
 func (p Problem) UploadPublicFile(ctx context.Context, c Client, localPath, key string) error {
-	return p.uploadAsPublic(ctx, c, localPath, p.publicFileKey(key))
+    return p.uploadAsPublic(ctx, c, localPath, p.publicFileKey(key))
+}
+
+// UploadPublicFileTo uploads a local file to an explicitly specified public remote URL.
+// This is useful for transitional migrations where multiple public schemas coexist.
+func (p Problem) UploadPublicFileTo(ctx context.Context, c Client, localPath, remoteURL string) error {
+    return p.uploadAsPublic(ctx, c, localPath, remoteURL)
 }
 
 func (p Problem) UploadPublicTestCase(ctx context.Context, c Client, localPath, key string) error {
-	return p.uploadAsPublic(ctx, c, localPath, p.publicTestCaseKey(key))
+    return p.uploadAsPublic(ctx, c, localPath, p.publicTestCaseKey(key))
+}
+
+// UploadPublicTestCaseV4 uploads example I/O to v4 examples path for Phase 1 dual-write.
+func (p Problem) UploadPublicTestCaseV4(ctx context.Context, c Client, localPath, key string) error {
+    return p.uploadAsPublic(ctx, c, localPath, p.v4ExamplesKey(key))
 }
 
 func (p Problem) uploadAsPublic(ctx context.Context, c Client, localPath, remoteURL string) error {
@@ -42,7 +64,7 @@ func (p Problem) uploadAsPublic(ctx context.Context, c Client, localPath, remote
 }
 
 func (p Problem) testCasesKey() string {
-	return fmt.Sprintf("%s.tar.gz", p.testCaseKeyPrefix())
+    return fmt.Sprintf("%s.tar.gz", p.testCaseKeyPrefix())
 }
 
 func (p Problem) publicTestCaseKey(key string) string {
@@ -50,15 +72,46 @@ func (p Problem) publicTestCaseKey(key string) string {
 }
 
 func (p Problem) testCaseKeyPrefix() string {
-	return fmt.Sprintf("v3/%s/testcase/%s", p.Name, p.TestCaseVersion)
+    return fmt.Sprintf("v3/%s/testcase/%s", p.Name, p.TestCaseVersion)
 }
 
 func (p Problem) publicFileKeyPrefix() string {
-	return fmt.Sprintf("v3/%s/files/%s", p.Name, p.Version)
+    return fmt.Sprintf("v3/%s/files/%s", p.Name, p.Version)
 }
 
 func (p Problem) publicFileKey(key string) string {
-	return fmt.Sprintf("%s/%s", p.publicFileKeyPrefix(), key)
+    return fmt.Sprintf("%s/%s", p.publicFileKeyPrefix(), key)
+}
+
+// v4 paths (Phase 1 dual-write)
+func (p Problem) v4TestCasesKey() string {
+    return fmt.Sprintf("v4/testcase/%s/%s.tar.gz", p.Name, p.TestCaseVersion)
+}
+
+func (p Problem) v4ExamplesKey(key string) string {
+    return fmt.Sprintf("v4/examples/%s/%s/%s", p.Name, p.TestCaseVersion, key)
+}
+
+func (p Problem) v4FilesCommonKey(key string) string {
+    // key is like "common/xxx" or just file under common. We accept both.
+    commonPath := key
+    if strings.HasPrefix(commonPath, "common/") {
+        commonPath = strings.TrimPrefix(commonPath, "common/")
+    }
+    return fmt.Sprintf("v4/files/%s/%s/common/%s", p.Name, p.OverallVersion, commonPath)
+}
+
+func (p Problem) v4FilesProblemKey(rel string) string {
+    // rel is path relative to the problem dir (e.g., "task.md", "sol/correct.cpp")
+    return fmt.Sprintf("v4/files/%s/%s/%s/%s", p.Name, p.OverallVersion, p.Name, rel)
+}
+
+// publicCommonV4Key returns the v4 path for common/* files only.
+// v4/files/{problem}/{version}/common/{path_under_common}
+func (p Problem) publicCommonV4Key(key string) string {
+    // key is expected like "common/fastio.h"
+    trimmed := strings.TrimPrefix(key, "common/")
+    return fmt.Sprintf("v4/files/%s/%s/common/%s", p.Name, p.Version, trimmed)
 }
 
 type Info struct {

--- a/storage/problem.go
+++ b/storage/problem.go
@@ -11,48 +11,48 @@ import (
 )
 
 type Problem struct {
-    Name            string
-    Version         string
-    OverallVersion  string
-    TestCaseVersion string
+	Name            string
+	Version         string
+	OverallVersion  string
+	TestCaseVersion string
 }
 
 func (p Problem) UploadTestCases(ctx context.Context, c Client, tarGzPath string) error {
-    remoteURL := p.testCasesKey()
-    slog.Info("Upload test cases", "remote", remoteURL)
-    if _, err := c.client.FPutObject(ctx, c.bucket, remoteURL, tarGzPath, minio.PutObjectOptions{}); err != nil {
-        return err
-    }
-    return nil
+	remoteURL := p.testCasesKey()
+	slog.Info("Upload test cases", "remote", remoteURL)
+	if _, err := c.client.FPutObject(ctx, c.bucket, remoteURL, tarGzPath, minio.PutObjectOptions{}); err != nil {
+		return err
+	}
+	return nil
 }
 
 // UploadTestCasesV4 uploads testcases tarball also to v4 private path for Phase 1 dual-write.
 func (p Problem) UploadTestCasesV4(ctx context.Context, c Client, tarGzPath string) error {
-    remoteURL := p.v4TestCasesKey()
-    slog.Info("Upload test cases (v4)", "remote", remoteURL)
-    if _, err := c.client.FPutObject(ctx, c.bucket, remoteURL, tarGzPath, minio.PutObjectOptions{}); err != nil {
-        return err
-    }
-    return nil
+	remoteURL := p.v4TestCasesKey()
+	slog.Info("Upload test cases (v4)", "remote", remoteURL)
+	if _, err := c.client.FPutObject(ctx, c.bucket, remoteURL, tarGzPath, minio.PutObjectOptions{}); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (p Problem) UploadPublicFile(ctx context.Context, c Client, localPath, key string) error {
-    return p.uploadAsPublic(ctx, c, localPath, p.publicFileKey(key))
+	return p.uploadAsPublic(ctx, c, localPath, p.publicFileKey(key))
 }
 
 // UploadPublicFileTo uploads a local file to an explicitly specified public remote URL.
 // This is useful for transitional migrations where multiple public schemas coexist.
 func (p Problem) UploadPublicFileTo(ctx context.Context, c Client, localPath, remoteURL string) error {
-    return p.uploadAsPublic(ctx, c, localPath, remoteURL)
+	return p.uploadAsPublic(ctx, c, localPath, remoteURL)
 }
 
 func (p Problem) UploadPublicTestCase(ctx context.Context, c Client, localPath, key string) error {
-    return p.uploadAsPublic(ctx, c, localPath, p.publicTestCaseKey(key))
+	return p.uploadAsPublic(ctx, c, localPath, p.publicTestCaseKey(key))
 }
 
 // UploadPublicTestCaseV4 uploads example I/O to v4 examples path for Phase 1 dual-write.
 func (p Problem) UploadPublicTestCaseV4(ctx context.Context, c Client, localPath, key string) error {
-    return p.uploadAsPublic(ctx, c, localPath, p.v4ExamplesKey(key))
+	return p.uploadAsPublic(ctx, c, localPath, p.v4ExamplesKey(key))
 }
 
 func (p Problem) uploadAsPublic(ctx context.Context, c Client, localPath, remoteURL string) error {
@@ -64,7 +64,7 @@ func (p Problem) uploadAsPublic(ctx context.Context, c Client, localPath, remote
 }
 
 func (p Problem) testCasesKey() string {
-    return fmt.Sprintf("%s.tar.gz", p.testCaseKeyPrefix())
+	return fmt.Sprintf("%s.tar.gz", p.testCaseKeyPrefix())
 }
 
 func (p Problem) publicTestCaseKey(key string) string {
@@ -72,46 +72,46 @@ func (p Problem) publicTestCaseKey(key string) string {
 }
 
 func (p Problem) testCaseKeyPrefix() string {
-    return fmt.Sprintf("v3/%s/testcase/%s", p.Name, p.TestCaseVersion)
+	return fmt.Sprintf("v3/%s/testcase/%s", p.Name, p.TestCaseVersion)
 }
 
 func (p Problem) publicFileKeyPrefix() string {
-    return fmt.Sprintf("v3/%s/files/%s", p.Name, p.Version)
+	return fmt.Sprintf("v3/%s/files/%s", p.Name, p.Version)
 }
 
 func (p Problem) publicFileKey(key string) string {
-    return fmt.Sprintf("%s/%s", p.publicFileKeyPrefix(), key)
+	return fmt.Sprintf("%s/%s", p.publicFileKeyPrefix(), key)
 }
 
 // v4 paths (Phase 1 dual-write)
 func (p Problem) v4TestCasesKey() string {
-    return fmt.Sprintf("v4/testcase/%s/%s.tar.gz", p.Name, p.TestCaseVersion)
+	return fmt.Sprintf("v4/testcase/%s/%s.tar.gz", p.Name, p.TestCaseVersion)
 }
 
 func (p Problem) v4ExamplesKey(key string) string {
-    return fmt.Sprintf("v4/examples/%s/%s/%s", p.Name, p.TestCaseVersion, key)
+	return fmt.Sprintf("v4/examples/%s/%s/%s", p.Name, p.TestCaseVersion, key)
 }
 
 func (p Problem) v4FilesCommonKey(key string) string {
-    // key is like "common/xxx" or just file under common. We accept both.
-    commonPath := key
-    if strings.HasPrefix(commonPath, "common/") {
-        commonPath = strings.TrimPrefix(commonPath, "common/")
-    }
-    return fmt.Sprintf("v4/files/%s/%s/common/%s", p.Name, p.OverallVersion, commonPath)
+	// key is like "common/xxx" or just file under common. We accept both.
+	commonPath := key
+	if strings.HasPrefix(commonPath, "common/") {
+		commonPath = strings.TrimPrefix(commonPath, "common/")
+	}
+	return fmt.Sprintf("v4/files/%s/%s/common/%s", p.Name, p.OverallVersion, commonPath)
 }
 
 func (p Problem) v4FilesProblemKey(rel string) string {
-    // rel is path relative to the problem dir (e.g., "task.md", "sol/correct.cpp")
-    return fmt.Sprintf("v4/files/%s/%s/%s/%s", p.Name, p.OverallVersion, p.Name, rel)
+	// rel is path relative to the problem dir (e.g., "task.md", "sol/correct.cpp")
+	return fmt.Sprintf("v4/files/%s/%s/%s/%s", p.Name, p.OverallVersion, p.Name, rel)
 }
 
 // publicCommonV4Key returns the v4 path for common/* files only.
-// v4/files/{problem}/{version}/common/{path_under_common}
+// v4/files/{problem}/{overall_version}/common/{path_under_common}
 func (p Problem) publicCommonV4Key(key string) string {
-    // key is expected like "common/fastio.h"
-    trimmed := strings.TrimPrefix(key, "common/")
-    return fmt.Sprintf("v4/files/%s/%s/common/%s", p.Name, p.Version, trimmed)
+	// key is expected like "common/fastio.h"
+	trimmed := strings.TrimPrefix(key, "common/")
+	return fmt.Sprintf("v4/files/%s/%s/common/%s", p.Name, p.OverallVersion, trimmed)
 }
 
 type Info struct {

--- a/storage/upload.go
+++ b/storage/upload.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"io/fs"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"sort"
@@ -17,9 +18,9 @@ import (
 )
 
 type UploadTarget struct {
-	Base    string
-	Root    string
-	Problem Problem
+    Base    string
+    Root    string
+    Problem Problem
 }
 
 type FileInfo struct {
@@ -93,23 +94,28 @@ func fileInfos(base, root string) []FileInfo {
 }
 
 func NewUploadTarget(base, root string) (UploadTarget, error) {
-	h, err := testCaseHash(base)
-	if err != nil {
-		return UploadTarget{}, err
-	}
-	v, err := version(base, root)
-	if err != nil {
-		return UploadTarget{}, err
-	}
-	return UploadTarget{
-		Root: root,
-		Base: base,
-		Problem: Problem{
-			Name:            path.Base(base),
-			TestCaseVersion: h,
-			Version:         v,
-		},
-	}, nil
+    h, err := testCaseHash(base)
+    if err != nil {
+        return UploadTarget{}, err
+    }
+    v, err := version(base, root)
+    if err != nil {
+        return UploadTarget{}, err
+    }
+    ov, err := overallVersion(base, root)
+    if err != nil {
+        return UploadTarget{}, err
+    }
+    return UploadTarget{
+        Root: root,
+        Base: base,
+        Problem: Problem{
+            Name:            path.Base(base),
+            TestCaseVersion: h,
+            Version:         v,
+            OverallVersion:  ov,
+        },
+    }, nil
 }
 
 func testCaseHash(base string) (string, error) {
@@ -130,52 +136,101 @@ func testCaseHash(base string) (string, error) {
 }
 
 func version(base, root string) (string, error) {
-	hashes := []string{}
+    hashes := []string{}
 
-	if h, err := testCaseHash(base); err != nil {
-		return "", err
-	} else {
-		hashes = append(hashes, h)
-	}
+    if h, err := testCaseHash(base); err != nil {
+        return "", err
+    } else {
+        hashes = append(hashes, h)
+    }
 
-	for _, info := range fileInfos(base, root) {
-		path := path.Join(info.base, info.path)
-		h, err := fileHash(path)
-		if info.required && err != nil {
-			return "", err
-		}
-		hashes = append(hashes, h)
-	}
+    for _, info := range fileInfos(base, root) {
+        path := path.Join(info.base, info.path)
+        h, err := fileHash(path)
+        if info.required && err != nil {
+            return "", err
+        }
+        hashes = append(hashes, h)
+    }
 
-	return joinHashes(hashes), nil
+    return joinHashes(hashes), nil
+}
+
+// overallVersion computes the v4 OverallVersion.
+// It includes TestCaseVersion and the content hash of all files under:
+//  - root/common/** (files only)
+//  - base/** (the entire problem dir; files only)
+func overallVersion(base, root string) (string, error) {
+    hashes := []string{}
+
+    if h, err := testCaseHash(base); err != nil {
+        return "", err
+    } else {
+        hashes = append(hashes, h)
+    }
+
+    commonFiles, problemFiles, err := gitTrackedFiles(base, root)
+    if err != nil {
+        return "", err
+    }
+
+    for _, rel := range commonFiles {
+        fp := path.Join(root, "common", rel)
+        h, err := fileHash(fp)
+        if err != nil {
+            return "", err
+        }
+        hashes = append(hashes, h)
+    }
+    for _, rel := range problemFiles {
+        fp := path.Join(root, rel)
+        h, err := fileHash(fp)
+        if err != nil {
+            return "", err
+        }
+        hashes = append(hashes, h)
+    }
+
+    return joinHashes(hashes), nil
 }
 
 func (p UploadTarget) UploadTestcases(client Client) error {
-	tarGz, err := p.BuildTestCaseTarGz()
-	if err != nil {
-		return err
-	}
-	defer func() { _ = os.Remove(tarGz) }()
+    tarGz, err := p.BuildTestCaseTarGz()
+    if err != nil {
+        return err
+    }
+    defer func() { _ = os.Remove(tarGz) }()
 
-	if err := p.Problem.UploadTestCases(context.Background(), client, tarGz); err != nil {
-		return err
-	}
+    // v3 upload
+    if err := p.Problem.UploadTestCases(context.Background(), client, tarGz); err != nil {
+        return err
+    }
 
-	// upload examples to the public bucket
-	for _, ext := range []string{"in", "out"} {
-		if err := filepath.Walk(path.Join(p.Base, ext), func(fpath string, info fs.FileInfo, err error) error {
-			if strings.Contains(fpath, "example") {
-				if err := p.Problem.UploadPublicTestCase(context.Background(), client, fpath, path.Join(ext, path.Base(fpath))); err != nil {
-					return err
-				}
-			}
-			return nil
-		}); err != nil {
-			return err
-		}
-	}
+    // v4 upload (private)
+    if err := p.Problem.UploadTestCasesV4(context.Background(), client, tarGz); err != nil {
+        return err
+    }
 
-	return nil
+    // upload examples to the public bucket
+    for _, ext := range []string{"in", "out"} {
+        if err := filepath.Walk(path.Join(p.Base, ext), func(fpath string, info fs.FileInfo, err error) error {
+            if strings.Contains(fpath, "example") {
+                // v3
+                if err := p.Problem.UploadPublicTestCase(context.Background(), client, fpath, path.Join(ext, path.Base(fpath))); err != nil {
+                    return err
+                }
+                // v4
+                if err := p.Problem.UploadPublicTestCaseV4(context.Background(), client, fpath, path.Join(ext, path.Base(fpath))); err != nil {
+                    return err
+                }
+            }
+            return nil
+        }); err != nil {
+            return err
+        }
+    }
+
+    return nil
 }
 
 func (p UploadTarget) BuildTestCaseTarGz() (string, error) {
@@ -234,21 +289,85 @@ func (p UploadTarget) BuildTestCaseTarGz() (string, error) {
 	return tempFile.Name(), nil
 }
 
-func (p UploadTarget) UploadPublicFiles(client Client) error {
-	for _, info := range fileInfos(p.Base, p.Root) {
-		src := path.Join(info.base, info.path)
-		if _, err := os.Stat(src); err != nil {
-			if info.required {
-				return fmt.Errorf("required file: %s/%s not found", info.base, info.path)
-			}
-			continue
-		}
+func (p UploadTarget) UploadPublicFilesV3(client Client) error {
+    for _, info := range fileInfos(p.Base, p.Root) {
+        src := path.Join(info.base, info.path)
+        if _, err := os.Stat(src); err != nil {
+            if info.required {
+                return fmt.Errorf("required file: %s/%s not found", info.base, info.path)
+            }
+            continue
+        }
 
-		if err := p.Problem.UploadPublicFile(context.Background(), client, src, info.path); err != nil {
-			return err
-		}
-	}
-	return nil
+        if err := p.Problem.UploadPublicFile(context.Background(), client, src, info.path); err != nil {
+            return err
+        }
+    }
+    return nil
+}
+
+func (p UploadTarget) UploadPublicFilesV4(client Client) error {
+    commonFiles, problemFiles, err := gitTrackedFiles(p.Base, p.Root)
+    if err != nil {
+        return err
+    }
+
+    for _, relCommon := range commonFiles {
+        local := path.Join(p.Root, "common", relCommon)
+        remote := p.Problem.v4FilesCommonKey(relCommon)
+        if err := p.Problem.UploadPublicFileTo(context.Background(), client, local, remote); err != nil {
+            return err
+        }
+    }
+
+    relProblemDir, err := filepath.Rel(p.Root, p.Base)
+    if err != nil {
+        return err
+    }
+    relProblemDir = filepath.ToSlash(relProblemDir)
+    prefix := relProblemDir + "/"
+
+    for _, rel := range problemFiles {
+        local := path.Join(p.Root, rel)
+        sub := strings.TrimPrefix(filepath.ToSlash(rel), prefix)
+        remote := p.Problem.v4FilesProblemKey(sub)
+        if err := p.Problem.UploadPublicFileTo(context.Background(), client, local, remote); err != nil {
+            return err
+        }
+    }
+    return nil
+}
+
+func gitTrackedFiles(base, root string) ([]string, []string, error) {
+    relProblemDir, err := filepath.Rel(root, base)
+    if err != nil {
+        return nil, nil, err
+    }
+    relProblemDir = filepath.ToSlash(relProblemDir)
+
+    cmd := exec.Command("git", "-C", root, "ls-files")
+    out, err := cmd.Output()
+    if err != nil {
+        return nil, nil, fmt.Errorf("git ls-files failed: %w", err)
+    }
+    lines := strings.Split(strings.ReplaceAll(string(out), "\r\n", "\n"), "\n")
+    commonFiles := []string{}
+    problemFiles := []string{}
+    for _, line := range lines {
+        if line == "" {
+            continue
+        }
+        p := filepath.ToSlash(line)
+        if strings.HasPrefix(p, "common/") {
+            commonFiles = append(commonFiles, strings.TrimPrefix(p, "common/"))
+            continue
+        }
+        if p == relProblemDir || strings.HasPrefix(p, relProblemDir+"/") {
+            problemFiles = append(problemFiles, p)
+            continue
+        }
+    }
+    return commonFiles, problemFiles, nil
 }
 
 func fileHash(path string) (string, error) {

--- a/uploader/problems/main.go
+++ b/uploader/problems/main.go
@@ -61,11 +61,11 @@ func main() {
 			slog.Error("Failed to build UploadTarget", "err", err)
 			os.Exit(1)
 		}
-        name := target.Problem.Name
-        v := target.Problem.Version
-        ov := target.Problem.OverallVersion
-        h := target.Problem.TestCaseVersion
-        slog.Info("Problem info", "name", name, "version", v, "overall_version", ov, "hash", h)
+		name := target.Problem.Name
+		v := target.Problem.Version
+		ov := target.Problem.OverallVersion
+		h := target.Problem.TestCaseVersion
+		slog.Info("Problem info", "name", name, "version", v, "overall_version", ov, "hash", h)
 
 		// fetch problem info from database
 		dbP, err := database.FetchProblem(db, name)
@@ -87,49 +87,49 @@ func main() {
 			os.Exit(1)
 		}
 
-        versionUpdated := (v != dbP.Version)
-        overallVersionUpdated := (ov != dbP.OverallVersion)
-        testcaseUpdated := (h != dbP.TestCasesVersion)
+		versionUpdated := (v != dbP.Version)
+		overallVersionUpdated := (ov != dbP.OverallVersion)
+		testcaseUpdated := (h != dbP.TestCasesVersion)
 
 		// update problem fields
 		dbP.Title = info.Title
 		dbP.Timelimit = int32(info.TimeLimit * 1000)
-        dbP.SourceUrl = toSourceURL(t)
-        dbP.Version = v
-        dbP.OverallVersion = ov
-        dbP.TestCasesVersion = h
+		dbP.SourceUrl = toSourceURL(t)
+		dbP.Version = v
+		dbP.OverallVersion = ov
+		dbP.TestCasesVersion = h
 
 		// upload test cases
-        if testcaseUpdated || *forceUpload {
-            if err := generate(*problemsDir, t); err != nil {
-                slog.Error("Failed to generate", "err", err)
-                os.Exit(1)
-            }
-            if err := target.UploadTestcases(storageClient); err != nil {
-                slog.Error("Failed to upload test cases", "err", err)
-                os.Exit(1)
-            }
-        } else {
-            slog.Info("Skip to upload test cases")
-        }
+		if testcaseUpdated || *forceUpload {
+			if err := generate(*problemsDir, t); err != nil {
+				slog.Error("Failed to generate", "err", err)
+				os.Exit(1)
+			}
+			if err := target.UploadTestcases(storageClient); err != nil {
+				slog.Error("Failed to upload test cases", "err", err)
+				os.Exit(1)
+			}
+		} else {
+			slog.Info("Skip to upload test cases")
+		}
 
 		// upload public files
-        if versionUpdated || *forceUpload {
-            if err := target.UploadPublicFilesV3(storageClient); err != nil {
-                slog.Error("Failed to upload public files", "err", err)
-                os.Exit(1)
-            }
-        }
+		if versionUpdated || *forceUpload {
+			if err := target.UploadPublicFilesV3(storageClient); err != nil {
+				slog.Error("Failed to upload public files", "err", err)
+				os.Exit(1)
+			}
+		}
 
-        if overallVersionUpdated || *forceUpload {
-            if err := target.UploadPublicFilesV4(storageClient); err != nil {
-                slog.Error("Failed to upload public files (v4)", "err", err)
-                os.Exit(1)
-            }
-        }
-        if !(versionUpdated || overallVersionUpdated || *forceUpload) {
-            slog.Info("Skip to upload public files")
-        }
+		if overallVersionUpdated || *forceUpload {
+			if err := target.UploadPublicFilesV4(storageClient); err != nil {
+				slog.Error("Failed to upload public files (v4)", "err", err)
+				os.Exit(1)
+			}
+		}
+		if !(versionUpdated || overallVersionUpdated || *forceUpload) {
+			slog.Info("Skip to upload public files")
+		}
 
 		if err := clean(*problemsDir, t); err != nil {
 			slog.Error("Failed to clean", "err", err)

--- a/uploader/problems/main.go
+++ b/uploader/problems/main.go
@@ -127,7 +127,7 @@ func main() {
 				os.Exit(1)
 			}
 		}
-		if !(versionUpdated || overallVersionUpdated || *forceUpload) {
+		if !versionUpdated && !overallVersionUpdated && !*forceUpload {
 			slog.Info("Skip to upload public files")
 		}
 

--- a/uploader/problems/main.go
+++ b/uploader/problems/main.go
@@ -61,10 +61,11 @@ func main() {
 			slog.Error("Failed to build UploadTarget", "err", err)
 			os.Exit(1)
 		}
-		name := target.Problem.Name
-		v := target.Problem.Version
-		h := target.Problem.TestCaseVersion
-		slog.Info("Problem info", "name", name, "version", v, "hash", h)
+        name := target.Problem.Name
+        v := target.Problem.Version
+        ov := target.Problem.OverallVersion
+        h := target.Problem.TestCaseVersion
+        slog.Info("Problem info", "name", name, "version", v, "overall_version", ov, "hash", h)
 
 		// fetch problem info from database
 		dbP, err := database.FetchProblem(db, name)
@@ -86,39 +87,49 @@ func main() {
 			os.Exit(1)
 		}
 
-		versionUpdated := (v != dbP.Version)
-		testcaseUpdated := (h != dbP.TestCasesVersion)
+        versionUpdated := (v != dbP.Version)
+        overallVersionUpdated := (ov != dbP.OverallVersion)
+        testcaseUpdated := (h != dbP.TestCasesVersion)
 
 		// update problem fields
 		dbP.Title = info.Title
 		dbP.Timelimit = int32(info.TimeLimit * 1000)
-		dbP.SourceUrl = toSourceURL(t)
-		dbP.Version = v
-		dbP.TestCasesVersion = h
+        dbP.SourceUrl = toSourceURL(t)
+        dbP.Version = v
+        dbP.OverallVersion = ov
+        dbP.TestCasesVersion = h
 
 		// upload test cases
-		if testcaseUpdated || *forceUpload {
-			if err := generate(*problemsDir, t); err != nil {
-				slog.Error("Failed to generate", "err", err)
-				os.Exit(1)
-			}
-			if err := target.UploadTestcases(storageClient); err != nil {
-				slog.Error("Failed to upload test cases", "err", err)
-				os.Exit(1)
-			}
-		} else {
-			slog.Info("Skip to upload test cases")
-		}
+        if testcaseUpdated || *forceUpload {
+            if err := generate(*problemsDir, t); err != nil {
+                slog.Error("Failed to generate", "err", err)
+                os.Exit(1)
+            }
+            if err := target.UploadTestcases(storageClient); err != nil {
+                slog.Error("Failed to upload test cases", "err", err)
+                os.Exit(1)
+            }
+        } else {
+            slog.Info("Skip to upload test cases")
+        }
 
 		// upload public files
-		if versionUpdated || *forceUpload {
-			if err := target.UploadPublicFiles(storageClient); err != nil {
-				slog.Error("Failed to upload public files", "err", err)
-				os.Exit(1)
-			}
-		} else {
-			slog.Info("Skip to upload public files")
-		}
+        if versionUpdated || *forceUpload {
+            if err := target.UploadPublicFilesV3(storageClient); err != nil {
+                slog.Error("Failed to upload public files", "err", err)
+                os.Exit(1)
+            }
+        }
+
+        if overallVersionUpdated || *forceUpload {
+            if err := target.UploadPublicFilesV4(storageClient); err != nil {
+                slog.Error("Failed to upload public files (v4)", "err", err)
+                os.Exit(1)
+            }
+        }
+        if !(versionUpdated || overallVersionUpdated || *forceUpload) {
+            slog.Info("Skip to upload public files")
+        }
 
 		if err := clean(*problemsDir, t); err != nil {
 			slog.Error("Failed to clean", "err", err)


### PR DESCRIPTION
- DB: add OverallVersion (AutoMigrate)
- storage: v4 keys (testcase/examples/files), dual-write uploads
- uploader: split UploadPublicFilesV3/V4, track OverallVersion triggers
- versioning: OverallVersion from git-tracked common/ and problem dir files
- docs: update v4 layout and migration plan