### PR TITLE
testing: split language coverage (judge=minimal, executor=all)

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -59,8 +59,8 @@ jobs:
       - name: Restart docker
         run: sudo service docker restart
 
-      - name: Pre-build language images
-        run: ./langs/build.sh
+      - name: Pre-build minimal language images (gcc + python3)
+        run: python3 ./langs/build.py gcc python3
 
       - name: Clone library-checker-problems
         run: |

--- a/.github/workflows/test-judge.yml
+++ b/.github/workflows/test-judge.yml
@@ -44,9 +44,9 @@ jobs:
 
     - name: Restart docker
       run: sudo service docker restart
-          
-    - name: Build lang images
-      run: ./build.sh
+
+    - name: Build minimal lang images (gcc + python3)
+      run: python3 ./build.py gcc python3
       working-directory: ./langs
 
     - name: Judge module test

--- a/docs/lang-images.md
+++ b/docs/lang-images.md
@@ -1,0 +1,79 @@
+# Docker 言語イメージとテストの設計方針
+
+本ドキュメントは library-checker-judge における「言語用 Docker イメージ」と、それを用いるテスト戦略（Judge/Executor/Integration）の役割分担と CI 方針をまとめます。CI 時間の短縮と責務の明確化が目的です。
+
+## 役割分担（結論）
+- Judge テスト（最小言語・ロジック検証）
+  - C++ と Python のみに限定した A+B と主要判定（AC/WA/PE/TLE/RE/CE/Fail）で、判定・進捗更新・チェック連携など「ロジック」を検証する。
+  - 多言語の正当性は Judge では担保しない（= 速度最優先）。
+- Executor テスト（全言語の実行検証）
+  - 全言語の A+B を実際にコンパイル・実行し、各言語イメージの健全性（ツールチェーン、実行環境、追加ファイルの取扱い等）を検証する。
+  - `executor/sources/aplusb/*` の各言語サンプルを使用。
+- Langs モジュール（定義とビルド）
+  - `langs/langs.toml` に言語ID/コンパイル・実行コマンド・`image_name` を定義。
+  - `Dockerfile.*` と `build.sh` で言語イメージをビルド。
+  - Langs/Executor に変更が入った場合は「全言語テスト」を走らせる。
+
+## 言語イメージの構成
+- 定義ファイル: `langs/`
+  - `langs.toml`: 言語ID・コンパイル/実行・`image_name` を定義
+  - `langs.go`: TOML を読み込み `LANGS` を構成。特殊言語（checker/verifier/generator）も定義
+  - `Dockerfile.*`: 各言語イメージ
+  - `build.sh`: 言語イメージのビルドスクリプト
+- 主なマッピング（例）
+  - C++ 系（`cpp`, `cpp20`, `cpp17`, `cpp-func`）→ `library-checker-images-gcc`
+  - Python 系（`python3`）→ `library-checker-images-python3`、（`pypy3`）→ `library-checker-images-pypy`
+  - `rust`→`...-rust`, `java`→`...-java`, `go`→`...-golang`, `haskell`→`...-haskell`, `csharp`→`...-csharp`, `swift`→`...-swift`, など
+  - 特殊言語: `checker`/`verifier`/`generator` は `library-checker-images-gcc` を使用（最小セットでも gcc は必須）
+
+## CI 方針（高速化を前提）
+- Judge（最小セット固定）
+  - ビルドするイメージ: `gcc` + `python3`（固定）。
+  - 実行: `go test ./judge -v`（C++/Python のみ）。
+  - 変更: Judge 側の変更では多言語は走らない。
+- Executor（全言語）
+  - ビルドするイメージ: 全言語。
+  - 実行: `go test ./executor -v`（各言語の A+B をコンパイル/実行して検証）。
+  - トリガー: Executor または Langs の変更時（既存の `test-executor.yml` の path で実現）。
+- Integration（最小 E2E）
+  - 既定は C++ の E2E（必要に応じて Python を追加可）。
+  - ビルドするイメージ: 最小セット固定（`gcc` + `python3`）。
+
+## 変更検知と切り替え（簡素化）
+- 追加の差分検知は不要。
+  - 既存のワークフロー分割で十分（`test-judge.yml` は Judge 変更時のみ、`test-executor.yml` は Executor/Langs 変更時のみ動作）。
+  - これにより通常は最小セット（Judge/Integration）、言語や実行基盤の変更時のみ全言語（Executor）という切り替えが自然に成立する。
+
+## 言語イメージのビルド戦略
+- 最小/全ビルドの切り替え
+  - 既定は「最小セット固定」: `gcc`（C++ + checker/verifier/generator）+ `python3`。
+  - Langs/Executor の変更時のみ「全ビルド」（`test-executor.yml` 側で全言語をビルド）。
+- ビルドコマンド（Python スクリプト）
+  - 全ビルド: `python3 langs/build.py`
+  - 最小: `python3 langs/build.py gcc python3`
+  - 利用可能なキー: `--list` で一覧表示（エイリアス: `d->ldc`, `go->golang`, `pypy3->pypy`, `cpp->gcc`）
+- キャッシュの活用
+  - まずは不要（buildx/GHCR は導入しない）。必要になったら将来検討する。
+
+## Executor 側の全言語 A+B テスト設計（案）
+- サンプルコード: `executor/sources/aplusb/*` を各言語向けに保持。
+- テスト内容（言語ごと）
+  - `executor.CompileSource` でコンパイル（`cpp-func` は grader/solve/fastio の追加ファイルを渡す）。
+  - `lang.Exec` で実行し、`sample.in` → `sample.out` の一致を検証。
+  - 実行環境・ツールチェーンの健全性を保証（Judge ではなく Executor の責務）。
+
+## 新規言語の追加手順（運用）
+1. `langs/Dockerfile.<LANG>` を追加し、ローカルで `docker build` 動作確認。
+2. `langs/langs.toml` に ID/コンパイル/実行/`image_name` を登録。
+3. `executor/sources/aplusb/` に最小 A+B のサンプルソースを追加。
+4. PR では Executor 全言語テスト（またはラベル/dispatch で強制）を通し、問題ないことを確認。
+
+## 注意点 / ベストプラクティス
+- `checker`/`verifier`/`generator` が `gcc` に依存するため、最小セットでも `gcc` は必須。
+- 重量級イメージ（Haskell/Swift等）は Executor/Langs の変更時にのみビルド・テストする方針で CI 時間を抑制。
+- 画像タグは `Lang.ImageName` と一致させ、変更時は TOML も合わせて更新。
+
+## ToDo（実装伴う作業）
+- `langs/build.sh` のサブセットビルド対応（`gcc python3` だけの最小ビルドを可能に）。
+- `test-judge.yml` と `test-integration.yml` を最小セットビルドに変更。
+- Executor の全言語 A+B スモークテストの整備。

--- a/executor/go.mod
+++ b/executor/go.mod
@@ -2,4 +2,9 @@ module github.com/yosupo06/library-checker-judge/executor
 
 go 1.21
 
-require github.com/google/uuid v1.3.0
+require (
+    github.com/google/uuid v1.3.0
+    github.com/yosupo06/library-checker-judge/langs v0.0.0-00010101000000-000000000000
+)
+
+replace github.com/yosupo06/library-checker-judge/langs => ../langs

--- a/executor/langs_aplusb_test.go
+++ b/executor/langs_aplusb_test.go
@@ -1,0 +1,166 @@
+package executor
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path"
+	"strings"
+	"testing"
+	"time"
+
+	lc "github.com/yosupo06/library-checker-judge/langs"
+)
+
+func writeTempFile(t *testing.T, r io.Reader, name string) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "ex-lang-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	fp := path.Join(dir, name)
+	if err := os.MkdirAll(path.Dir(fp), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Create(fp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.Copy(f, r); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+	return fp
+}
+
+// map language id -> sample source path in embed FS
+func samplePathFor(langID string) (string, map[string]string) {
+	// additional files map: filename -> embedded path
+	add := map[string]string{}
+	switch langID {
+	case "cpp", "cpp20", "cpp17":
+		return "sources/aplusb/ac.cpp", nil
+	case "cpp-func":
+		add["grader.cpp"] = "sources/aplusb/cpp-func/grader.cpp"
+		add["solve.hpp"] = "sources/aplusb/cpp-func/solve.hpp"
+		add["fastio.h"] = "sources/aplusb/cpp-func/fastio.h"
+		return "sources/aplusb/ac_func.cpp", add
+	case "rust":
+		return "sources/aplusb/ac.rs", nil
+	case "java":
+		return "sources/aplusb/ac.java", nil
+	case "go":
+		return "sources/aplusb/go/ac.go", nil
+	case "haskell":
+		return "sources/aplusb/ac.hs", nil
+	case "csharp":
+		return "sources/aplusb/ac.cs", nil
+	case "d":
+		return "sources/aplusb/ac.d", nil
+	case "crystal":
+		return "sources/aplusb/ac.cr", nil
+	case "ruby":
+		return "sources/aplusb/ac.rb", nil
+	case "lisp":
+		return "sources/aplusb/ac.lisp", nil
+	case "swift":
+		return "sources/aplusb/ac.swift", nil
+	case "python3":
+		return "sources/aplusb/ac_numpy.py", nil
+	case "pypy3":
+		return "sources/aplusb/ac.py", nil
+	default:
+		return "", nil
+	}
+}
+
+func TestAllLangsAplusB_Smoke(t *testing.T) {
+	// Load sample IO
+	inBytes, err := Sources.ReadFile("sources/aplusb/sample.in")
+	if err != nil {
+		t.Fatal(err)
+	}
+	outBytes, err := Sources.ReadFile("sources/aplusb/sample.out")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := strings.TrimSpace(string(outBytes))
+
+	for _, lang := range lc.LANGS {
+		srcPath, add := samplePathFor(lang.ID)
+		if srcPath == "" {
+			// No sample for this language; skip silently
+			continue
+		}
+		t.Run(lang.ID, func(t *testing.T) {
+			// Write source to temp
+			src, err := Sources.Open(srcPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer src.Close()
+			srcFile := writeTempFile(t, src, path.Base(lang.Source))
+
+			// Prepare additional files
+			extra := map[string]string{}
+			for name, embedded := range add {
+				r, err := Sources.Open(embedded)
+				if err != nil {
+					t.Fatal(err)
+				}
+				extra[name] = writeTempFile(t, r, name)
+				_ = r.Close()
+			}
+
+			// Compile
+			vol, compRes, err := CompileSource(srcFile, executorLangFrom(lang), []TaskInfoOption{}, 2*time.Minute, extra)
+			if err != nil {
+				t.Fatalf("compile error: %v", err)
+			}
+			if compRes.ExitCode != 0 {
+				t.Fatalf("compile failed: exit=%d, stderr=%s", compRes.ExitCode, string(compRes.Stderr))
+			}
+			defer func() { _ = vol.Remove() }()
+
+			// Execute
+			stdout := new(bytes.Buffer)
+			runTask, err := NewTaskInfo(lang.ImageName,
+				WithArguments(lang.Exec...),
+				WithWorkDir("/workdir"),
+				WithVolume(&vol, "/workdir"),
+				WithStdout(stdout),
+				WithStdin(bytes.NewReader(inBytes)),
+				WithTimeout(30*time.Second),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			res, err := runTask.Run()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if res.ExitCode != 0 {
+				t.Fatalf("run failed: exit=%d, stderr=%s", res.ExitCode, string(res.Stderr))
+			}
+			got := strings.TrimSpace(stdout.String())
+			if got != expected {
+				t.Fatalf("wrong output: want %q, got %q", expected, got)
+			}
+		})
+	}
+}
+
+// executorLangFrom converts langs.Lang to executor.Lang
+func executorLangFrom(l lc.Lang) Lang {
+	return Lang{
+		ID:              l.ID,
+		Name:            l.Name,
+		Version:         l.Version,
+		Source:          l.Source,
+		Compile:         l.Compile,
+		Exec:            l.Exec,
+		ImageName:       l.ImageName,
+		AdditionalFiles: l.AdditionalFiles,
+	}
+}

--- a/judge/judge_test.go
+++ b/judge/judge_test.go
@@ -144,51 +144,11 @@ func TestCppAplusBAC(t *testing.T) {
 func TestCppAclAplusBAC(t *testing.T) {
 	testAplusBAC(t, "cpp", "ac_acl.cpp")
 }
-func TestRustAplusBAC(t *testing.T) {
-	testAplusBAC(t, "rust", "ac.rs")
-}
-
-func TestHaskellAplusBAC(t *testing.T) {
-	testAplusBAC(t, "haskell", "ac.hs")
-}
-
-func TestHaskellCabalAplusBAC(t *testing.T) {
-	testAplusBAC(t, "haskell", "ac_cabal.hs")
-}
-
-func TestCSharpAplusBAC(t *testing.T) {
-	testAplusBAC(t, "csharp", "ac.cs")
-}
-
-func TestLispAplusBAC(t *testing.T) {
-	testAplusBAC(t, "lisp", "ac.lisp")
-}
 
 func TestPython3AplusBAC(t *testing.T) {
 	testAplusBAC(t, "python3", "ac_numpy.py")
 }
 
-func TestPyPy3AplusBAC(t *testing.T) {
-	testAplusBAC(t, "pypy3", "ac.py")
-}
-func TestDAplusBAC(t *testing.T) {
-	testAplusBAC(t, "d", "ac.d")
-}
-func TestJavaAplusBAC(t *testing.T) {
-	testAplusBAC(t, "java", "ac.java")
-}
-func TestGoAplusBAC(t *testing.T) {
-	testAplusBAC(t, "go", "go/ac.go")
-}
-func TestCrystalAplusBAC(t *testing.T) {
-	testAplusBAC(t, "crystal", "ac.cr")
-}
-func TestRubyAplusBAC(t *testing.T) {
-	testAplusBAC(t, "ruby", "ac.rb")
-}
-func TestSwiftAplusBAC(t *testing.T) {
-	testAplusBAC(t, "swift", "ac.swift")
-}
 
 func TestCppAplusBWA(t *testing.T) {
 	testAplusB(t, "cpp", "wa.cpp", SAMPLE_IN_PATH, SAMPLE_OUT_PATH, "WA")

--- a/langs/build.py
+++ b/langs/build.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+# key -> (dockerfile suffix, image tag)
+IMAGES = {
+    "gcc": ("GCC", "library-checker-images-gcc"),
+    "ldc": ("LDC", "library-checker-images-ldc"),  # D (ldc)
+    "python3": ("PYTHON3", "library-checker-images-python3"),
+    "haskell": ("HASKELL", "library-checker-images-haskell"),
+    "csharp": ("CSHARP", "library-checker-images-csharp"),
+    "rust": ("RUST", "library-checker-images-rust"),
+    "java": ("JAVA", "library-checker-images-java"),
+    "pypy": ("PYPY", "library-checker-images-pypy"),
+    "golang": ("GOLANG", "library-checker-images-golang"),
+    "lisp": ("LISP", "library-checker-images-lisp"),
+    "crystal": ("CRYSTAL", "library-checker-images-crystal"),
+    "ruby": ("RUBY", "library-checker-images-ruby"),
+    "swift": ("SWIFT", "library-checker-images-swift"),
+}
+
+# Aliases for convenience
+ALIASES = {
+    "d": "ldc",
+    "go": "golang",
+    "pypy3": "pypy",
+    # cpp-related languages use gcc image but are not images themselves
+    # expose a helper so users can say `cpp` and we still build gcc
+    "cpp": "gcc",
+}
+
+
+def normalize_keys(keys):
+    result = []
+    for k in keys:
+        norm = ALIASES.get(k, k)
+        if norm not in IMAGES:
+            raise SystemExit(f"Unknown image key: {k}")
+        result.append(norm)
+    # de-duplicate while preserving order
+    seen = set()
+    deduped = []
+    for k in result:
+        if k not in seen:
+            deduped.append(k)
+            seen.add(k)
+    return deduped
+
+
+def build_one(key):
+    suffix, tag = IMAGES[key]
+    dockerfile = SCRIPT_DIR / f"Dockerfile.{suffix}"
+    cmd = [
+        "docker", "build",
+        "-t", tag,
+        "-f", str(dockerfile),
+        str(SCRIPT_DIR),
+    ]
+    print("+", " ".join(cmd), flush=True)
+    subprocess.run(cmd, check=True)
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description="Build language Docker images")
+    parser.add_argument(
+        "images",
+        nargs="*",
+        help=(
+            "Image keys to build (default: all). "
+            "Examples: gcc python3 | all. Aliases: d->ldc, go->golang, pypy3->pypy, cpp->gcc"
+        ),
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List available image keys and exit",
+    )
+    args = parser.parse_args(argv)
+
+    if args.list:
+        print("Available images:")
+        for k in IMAGES:
+            print(" -", k)
+        print("Aliases:")
+        for a, t in ALIASES.items():
+            print(f" - {a} -> {t}")
+        return 0
+
+    if not args.images or (len(args.images) == 1 and args.images[0] == "all"):
+        keys = list(IMAGES.keys())
+    else:
+        keys = normalize_keys(args.images)
+
+    for key in keys:
+        build_one(key)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/langs/build.sh
+++ b/langs/build.sh
@@ -1,19 +1,4 @@
 #!/usr/bin/env bash
-
-set -e
-
-SCRIPT_DIR=$(cd $(dirname $0); pwd)
-
-docker build -t library-checker-images-gcc -f $SCRIPT_DIR/Dockerfile.GCC $SCRIPT_DIR
-docker build -t library-checker-images-ldc -f $SCRIPT_DIR/Dockerfile.LDC $SCRIPT_DIR
-docker build -t library-checker-images-python3 -f $SCRIPT_DIR/Dockerfile.PYTHON3 $SCRIPT_DIR
-docker build -t library-checker-images-haskell -f $SCRIPT_DIR/Dockerfile.HASKELL $SCRIPT_DIR
-docker build -t library-checker-images-csharp -f $SCRIPT_DIR/Dockerfile.CSHARP $SCRIPT_DIR
-docker build -t library-checker-images-rust -f $SCRIPT_DIR/Dockerfile.RUST $SCRIPT_DIR
-docker build -t library-checker-images-java -f $SCRIPT_DIR/Dockerfile.JAVA $SCRIPT_DIR
-docker build -t library-checker-images-pypy -f $SCRIPT_DIR/Dockerfile.PYPY $SCRIPT_DIR
-docker build -t library-checker-images-golang -f $SCRIPT_DIR/Dockerfile.GOLANG $SCRIPT_DIR
-docker build -t library-checker-images-lisp -f $SCRIPT_DIR/Dockerfile.LISP $SCRIPT_DIR
-docker build -t library-checker-images-crystal -f $SCRIPT_DIR/Dockerfile.CRYSTAL $SCRIPT_DIR
-docker build -t library-checker-images-ruby -f $SCRIPT_DIR/Dockerfile.RUBY $SCRIPT_DIR
-docker build -t library-checker-images-swift -f $SCRIPT_DIR/Dockerfile.SWIFT $SCRIPT_DIR
+set -euo pipefail
+SCRIPT_DIR=$(cd "$(dirname "$0")"; pwd)
+exec python3 "$SCRIPT_DIR/build.py" "$@"


### PR DESCRIPTION
Summary
- Judge: test only C++ + Python (fast path)
- Executor: add full-language A+B smoke test (incl. swift)
- Langs: new build.py (argparse) + build.sh wrapper; CI uses minimal gcc+python3
- Docs: update docs/lang-images.md to reflect plan

CI
- test-judge: builds minimal images via build.py gcc python3
- test-executor: builds all images and runs per-language A+B via executor tests
- test-integration: uses minimal images

Notes
- executor/langs_aplusb_test.go uses langs as test dependency (replace ../langs).
- cpp-func sample compiles with grader/solve/fastio injected.
