### PR TITLE
feat(restapi): add /langs and /categories; add unit + integration tests; chore: apply pre-commit fixes

### DIFF
--- a/.github/workflows/lint-restapi.yml
+++ b/.github/workflows/lint-restapi.yml
@@ -6,12 +6,14 @@ on:
       - master
     paths:
       - 'restapi/**'
-      - 'database/**'  # restapi depends on database
+      - 'database/**'
+      - 'langs/**'
       - '.github/workflows/lint-restapi.yml'
   pull_request:
     paths:
       - 'restapi/**'
-      - 'database/**'  # restapi depends on database
+      - 'database/**'
+      - 'langs/**'
       - '.github/workflows/lint-restapi.yml'
 
 jobs:

--- a/integration/rest_api_test.go
+++ b/integration/rest_api_test.go
@@ -108,3 +108,89 @@ func TestREST_ProblemsAndInfo(t *testing.T) {
 		t.Fatalf("invalid problem info: %+v", info)
 	}
 }
+
+func TestREST_LangsAndCategories(t *testing.T) {
+    // Ensure REST server is up
+    if err := waitForREST(t, "http://localhost:12381/health", 2*time.Minute); err != nil {
+        t.Fatalf("REST /health not ready: %v", err)
+    }
+
+    client := &http.Client{Timeout: 5 * time.Second}
+
+    // GET /langs
+    resp, err := client.Get("http://localhost:12381/langs")
+    if err != nil {
+        t.Fatalf("GET /langs failed: %v", err)
+    }
+    defer func() { _ = resp.Body.Close() }()
+    if resp.StatusCode != 200 {
+        t.Fatalf("GET /langs status=%d", resp.StatusCode)
+    }
+    var langs struct {
+        Langs []struct {
+            ID      string `json:"id"`
+            Name    string `json:"name"`
+            Version string `json:"version"`
+        } `json:"langs"`
+    }
+    if err := json.NewDecoder(resp.Body).Decode(&langs); err != nil {
+        t.Fatalf("decode /langs failed: %v", err)
+    }
+    if len(langs.Langs) == 0 {
+        t.Fatalf("/langs returned empty list")
+    }
+    foundCpp := false
+    for _, l := range langs.Langs {
+        if l.ID == "cpp" {
+            foundCpp = true
+        }
+        if l.ID == "" || l.Name == "" || l.Version == "" {
+            t.Fatalf("invalid lang entry: %+v", l)
+        }
+    }
+    if !foundCpp {
+        t.Fatalf("cpp not found in /langs")
+    }
+
+    // GET /categories (poll until non-empty because uploader populates metadata)
+    var catsResp *http.Response
+    var lastErr error
+    deadline := time.Now().Add(2 * time.Minute)
+    for time.Now().Before(deadline) {
+        catsResp, lastErr = client.Get("http://localhost:12381/categories")
+        if lastErr == nil && catsResp.StatusCode == 200 {
+            break
+        }
+        time.Sleep(2 * time.Second)
+    }
+    if lastErr != nil {
+        t.Fatalf("GET /categories failed: %v", lastErr)
+    }
+    defer func() { _ = catsResp.Body.Close() }()
+    var categories struct {
+        Categories []struct {
+            Title    string   `json:"title"`
+            Problems []string `json:"problems"`
+        } `json:"categories"`
+    }
+    if err := json.NewDecoder(catsResp.Body).Decode(&categories); err != nil {
+        t.Fatalf("decode /categories failed: %v", err)
+    }
+    if len(categories.Categories) == 0 {
+        t.Fatalf("/categories returned empty list")
+    }
+    hasUnionFind := false
+    for _, c := range categories.Categories {
+        if c.Title == "" || len(c.Problems) == 0 {
+            t.Fatalf("invalid category: %+v", c)
+        }
+        for _, p := range c.Problems {
+            if p == "unionfind" {
+                hasUnionFind = true
+            }
+        }
+    }
+    if !hasUnionFind {
+        t.Fatalf("unionfind not present in any category list")
+    }
+}

--- a/integration/rest_api_test.go
+++ b/integration/rest_api_test.go
@@ -110,87 +110,87 @@ func TestREST_ProblemsAndInfo(t *testing.T) {
 }
 
 func TestREST_LangsAndCategories(t *testing.T) {
-    // Ensure REST server is up
-    if err := waitForREST(t, "http://localhost:12381/health", 2*time.Minute); err != nil {
-        t.Fatalf("REST /health not ready: %v", err)
-    }
+	// Ensure REST server is up
+	if err := waitForREST(t, "http://localhost:12381/health", 2*time.Minute); err != nil {
+		t.Fatalf("REST /health not ready: %v", err)
+	}
 
-    client := &http.Client{Timeout: 5 * time.Second}
+	client := &http.Client{Timeout: 5 * time.Second}
 
-    // GET /langs
-    resp, err := client.Get("http://localhost:12381/langs")
-    if err != nil {
-        t.Fatalf("GET /langs failed: %v", err)
-    }
-    defer func() { _ = resp.Body.Close() }()
-    if resp.StatusCode != 200 {
-        t.Fatalf("GET /langs status=%d", resp.StatusCode)
-    }
-    var langs struct {
-        Langs []struct {
-            ID      string `json:"id"`
-            Name    string `json:"name"`
-            Version string `json:"version"`
-        } `json:"langs"`
-    }
-    if err := json.NewDecoder(resp.Body).Decode(&langs); err != nil {
-        t.Fatalf("decode /langs failed: %v", err)
-    }
-    if len(langs.Langs) == 0 {
-        t.Fatalf("/langs returned empty list")
-    }
-    foundCpp := false
-    for _, l := range langs.Langs {
-        if l.ID == "cpp" {
-            foundCpp = true
-        }
-        if l.ID == "" || l.Name == "" || l.Version == "" {
-            t.Fatalf("invalid lang entry: %+v", l)
-        }
-    }
-    if !foundCpp {
-        t.Fatalf("cpp not found in /langs")
-    }
+	// GET /langs
+	resp, err := client.Get("http://localhost:12381/langs")
+	if err != nil {
+		t.Fatalf("GET /langs failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != 200 {
+		t.Fatalf("GET /langs status=%d", resp.StatusCode)
+	}
+	var langs struct {
+		Langs []struct {
+			ID      string `json:"id"`
+			Name    string `json:"name"`
+			Version string `json:"version"`
+		} `json:"langs"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&langs); err != nil {
+		t.Fatalf("decode /langs failed: %v", err)
+	}
+	if len(langs.Langs) == 0 {
+		t.Fatalf("/langs returned empty list")
+	}
+	foundCpp := false
+	for _, l := range langs.Langs {
+		if l.ID == "cpp" {
+			foundCpp = true
+		}
+		if l.ID == "" || l.Name == "" || l.Version == "" {
+			t.Fatalf("invalid lang entry: %+v", l)
+		}
+	}
+	if !foundCpp {
+		t.Fatalf("cpp not found in /langs")
+	}
 
-    // GET /categories (poll until non-empty because uploader populates metadata)
-    var catsResp *http.Response
-    var lastErr error
-    deadline := time.Now().Add(2 * time.Minute)
-    for time.Now().Before(deadline) {
-        catsResp, lastErr = client.Get("http://localhost:12381/categories")
-        if lastErr == nil && catsResp.StatusCode == 200 {
-            break
-        }
-        time.Sleep(2 * time.Second)
-    }
-    if lastErr != nil {
-        t.Fatalf("GET /categories failed: %v", lastErr)
-    }
-    defer func() { _ = catsResp.Body.Close() }()
-    var categories struct {
-        Categories []struct {
-            Title    string   `json:"title"`
-            Problems []string `json:"problems"`
-        } `json:"categories"`
-    }
-    if err := json.NewDecoder(catsResp.Body).Decode(&categories); err != nil {
-        t.Fatalf("decode /categories failed: %v", err)
-    }
-    if len(categories.Categories) == 0 {
-        t.Fatalf("/categories returned empty list")
-    }
-    hasUnionFind := false
-    for _, c := range categories.Categories {
-        if c.Title == "" || len(c.Problems) == 0 {
-            t.Fatalf("invalid category: %+v", c)
-        }
-        for _, p := range c.Problems {
-            if p == "unionfind" {
-                hasUnionFind = true
-            }
-        }
-    }
-    if !hasUnionFind {
-        t.Fatalf("unionfind not present in any category list")
-    }
+	// GET /categories (poll until non-empty because uploader populates metadata)
+	var catsResp *http.Response
+	var lastErr error
+	deadline := time.Now().Add(2 * time.Minute)
+	for time.Now().Before(deadline) {
+		catsResp, lastErr = client.Get("http://localhost:12381/categories")
+		if lastErr == nil && catsResp.StatusCode == 200 {
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
+	if lastErr != nil {
+		t.Fatalf("GET /categories failed: %v", lastErr)
+	}
+	defer func() { _ = catsResp.Body.Close() }()
+	var categories struct {
+		Categories []struct {
+			Title    string   `json:"title"`
+			Problems []string `json:"problems"`
+		} `json:"categories"`
+	}
+	if err := json.NewDecoder(catsResp.Body).Decode(&categories); err != nil {
+		t.Fatalf("decode /categories failed: %v", err)
+	}
+	if len(categories.Categories) == 0 {
+		t.Fatalf("/categories returned empty list")
+	}
+	hasUnionFind := false
+	for _, c := range categories.Categories {
+		if c.Title == "" || len(c.Problems) == 0 {
+			t.Fatalf("invalid category: %+v", c)
+		}
+		for _, p := range c.Problems {
+			if p == "unionfind" {
+				hasUnionFind = true
+			}
+		}
+	}
+	if !hasUnionFind {
+		t.Fatalf("unionfind not present in any category list")
+	}
 }

--- a/restapi/go.mod
+++ b/restapi/go.mod
@@ -7,10 +7,12 @@ require (
 	github.com/go-chi/chi/v5 v5.1.0
 	github.com/oapi-codegen/runtime v1.1.2
 	github.com/yosupo06/library-checker-judge/database v0.0.0-00010101000000-000000000000
+	github.com/yosupo06/library-checker-judge/langs v0.0.0-00010101000000-000000000000
 	gorm.io/gorm v1.25.11
 )
 
 require (
+	github.com/BurntSushi/toml v1.4.0 // indirect
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.4 // indirect
@@ -49,5 +51,7 @@ require (
 )
 
 replace github.com/yosupo06/library-checker-judge/database => ../database
+
+replace github.com/yosupo06/library-checker-judge/langs => ../langs
 
 tool github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen

--- a/restapi/go.sum
+++ b/restapi/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
+github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=

--- a/restapi/internal/api/api.gen.go
+++ b/restapi/internal/api/api.gen.go
@@ -18,10 +18,33 @@ import (
 	"github.com/oapi-codegen/runtime"
 )
 
+// Lang defines model for Lang.
+type Lang struct {
+	Id      string `json:"id"`
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// LangListResponse defines model for LangListResponse.
+type LangListResponse struct {
+	Langs []Lang `json:"langs"`
+}
+
 // Problem defines model for Problem.
 type Problem struct {
 	Name  string `json:"name"`
 	Title string `json:"title"`
+}
+
+// ProblemCategoriesResponse defines model for ProblemCategoriesResponse.
+type ProblemCategoriesResponse struct {
+	Categories []ProblemCategory `json:"categories"`
+}
+
+// ProblemCategory defines model for ProblemCategory.
+type ProblemCategory struct {
+	Problems []string `json:"problems"`
+	Title    string   `json:"title"`
 }
 
 // ProblemInfoResponse defines model for ProblemInfoResponse.
@@ -59,6 +82,12 @@ type GetRankingParams struct {
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
+	// Get problem categories
+	// (GET /categories)
+	GetProblemCategories(w http.ResponseWriter, r *http.Request)
+	// Get language list
+	// (GET /langs)
+	GetLangList(w http.ResponseWriter, r *http.Request)
 	// Get problems
 	// (GET /problems)
 	GetProblems(w http.ResponseWriter, r *http.Request)
@@ -73,6 +102,18 @@ type ServerInterface interface {
 // Unimplemented server implementation that returns http.StatusNotImplemented for each endpoint.
 
 type Unimplemented struct{}
+
+// Get problem categories
+// (GET /categories)
+func (_ Unimplemented) GetProblemCategories(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get language list
+// (GET /langs)
+func (_ Unimplemented) GetLangList(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
 
 // Get problems
 // (GET /problems)
@@ -100,6 +141,34 @@ type ServerInterfaceWrapper struct {
 }
 
 type MiddlewareFunc func(http.Handler) http.Handler
+
+// GetProblemCategories operation middleware
+func (siw *ServerInterfaceWrapper) GetProblemCategories(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetProblemCategories(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetLangList operation middleware
+func (siw *ServerInterfaceWrapper) GetLangList(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetLangList(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
 
 // GetProblems operation middleware
 func (siw *ServerInterfaceWrapper) GetProblems(w http.ResponseWriter, r *http.Request) {
@@ -289,6 +358,12 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	}
 
 	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/categories", wrapper.GetProblemCategories)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/langs", wrapper.GetLangList)
+	})
+	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/problems", wrapper.GetProblems)
 	})
 	r.Group(func(r chi.Router) {
@@ -304,16 +379,18 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/7SVT2vbTBDGv4qZ9z20ICwluelWSimhgYakPYUQ1vLYmUT7J7OjgDH67mV3Lct2JMel",
-	"5OSFHc0+z++ZXa+hstpZg0Y8lGvw1SNqFZfXbGc16rB0bB2yEMYNozSGX1k5hBK8MJkltBkIST2002bA",
-	"+NIQ4xzKu/R9V32fddV29oSVhD6bky/Nwt6gd9Z4fKvCviKrun54RfZkzaAgbxuu8KHhelgveqmUR3+0",
-	"iZDGh5o0SdheWNZKoIRFbZXAVr1p9Az5GIUMxk85IJRa7Onf09G3GjKRvWFzBPIVeRmH7FJRXJNsFv8z",
-	"LqCE//J+dPLN3OTd0LTbExWzWr1xuG08JO1GmWcyy3FZlW3Mfhpk5OK8T4OM4DLF4UUJeaHqdBO/PfJt",
-	"/9l7XnZOyDbShlwddP0nUyNXcPiijUkK5WQWNjZKQwtXNGPFq8nXR6yekSc3325/Tb5cX04+aTKkVf15",
-	"Z/hKKKZn0yIIsg6NcgQlXEyL6QVk4JQ8Rl/57hAtMVoMvpWQNZdzKOE7ynVXExyk2GP9eVEkNkYw0VHO",
-	"1VTFj/Mnn25TCu7E2dyb+Ahhjr5icpI8/fwRQfpGa8WrJG+y9RC2to7ydUDcnmAsvGURCiuNguyhvFsD",
-	"hfMCKOgi7TLrYxRuMNtxeBj5/ccT23uI/5LYJE5YpMbpWh+jtbn5I6ReGuRVj8o/k4NdNHNcqKYWKIvs",
-	"/UvUZsNduxd2oO1ZcVLjj0zk8Gk8NY2Ofaz3yK8d2PjfCDm09+2fAAAA//8Bbn4oDAgAAA==",
+	"H4sIAAAAAAAC/7xWzWrcPBR9FXO/b9GCGTvJzrsSSgkNNCTtKoSg8dxxlFiSI10HhsHvXiSNx3b8m5bp",
+	"JjHjq6Nzzv3zHlIlCiVRkoFkDyZ9QsHc4zWTmf1faFWgJo7uV76xf2lXICRgSHOZQRWCZAIHX7yhNlzJ",
+	"gXdVCBpfS65xA8m9BT7ANIcewvqQWj9jShbQ0rrmhm7RFEoa7FPMmcw8V0LhHv7XuIUE/osasdFBaeRk",
+	"VseLmNZs1yPnIYfo3Gi1zlH0WYw6QpxynPfjYIWPnrj5khFmSnM0446kx5jFtnTRd7MOta6YJ7vrUyx8",
+	"QJdg37sOhcVe+rCwuWSC4pXcqnEn1RtqlueP42UdglGlTvGx1PmwBjSUMoNmEoS4wMecC0729VZpwQgS",
+	"2OaKERzZy1KsUU858YEOrF1q8e/waKCGRIQ9byZMnm7gwVpYUKyzRTqZ/1smX7jMJrpIlbKbDS7p4rzJ",
+	"BpeEmU+HIUbcEE+Xi/hlUN81x+a0tG4ID9SGVL1D/StRIyNteHCNUbLhXG6VA/JFC9d8rZneBZdPmL6g",
+	"Dm6/3v0MvtxcBZ8El1yw/HOr+BKIV2er2BJSBUpWcEjgYhWvLmyHM3pyuqLuzMvQibTKGXElrzaQwDek",
+	"3hAFK8ZXgDt4HsfeJknojWJFkfPUoUTPxjeWz+HHZmp7YjtXNmhSzQvyIn98d86aUghmB6ZlGxwKOGiJ",
+	"s0HRceWN6ay35inl9TbzUlWWfckyDHLL0Alqj4CZ3P2LlP2RrKOGjqJobxukWiDMbiJX0poJJNQGkvs9",
+	"cHufLfP6cympO65pQtIlhi2F7xv24fSOddboR8vbzQfnmvZDecqtw9weceq1RL1rrDIvvIC2NRvcsjIn",
+	"SOJwfgRW4TBqvR8HYM/iRcCnzMj7xbY0G7X3Lt6gfquNdV82EEH1UP0OAAD//3V94fRADAAA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/restapi/main.go
+++ b/restapi/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/yosupo06/library-checker-judge/database"
+	"github.com/yosupo06/library-checker-judge/langs"
 	restapi "github.com/yosupo06/library-checker-judge/restapi/internal/api"
 	"gorm.io/gorm"
 )
@@ -88,6 +89,33 @@ func (s *server) GetProblemInfo(w http.ResponseWriter, r *http.Request, name str
 		TestcasesVersion: p.TestCasesVersion,
 		OverallVersion:   p.OverallVersion,
 	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// GetLangList handles GET /langs
+func (s *server) GetLangList(w http.ResponseWriter, r *http.Request) {
+	var ls []restapi.Lang
+	for _, l := range langs.LANGS {
+		ls = append(ls, restapi.Lang{Id: l.ID, Name: l.Name, Version: l.Version})
+	}
+	resp := restapi.LangListResponse{Langs: ls}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// GetProblemCategories handles GET /categories
+func (s *server) GetProblemCategories(w http.ResponseWriter, r *http.Request) {
+	cats, err := database.FetchProblemCategories(s.db)
+	if err != nil {
+		http.Error(w, "failed to fetch categories", http.StatusInternalServerError)
+		return
+	}
+	result := make([]restapi.ProblemCategory, 0, len(cats))
+	for _, c := range cats {
+		result = append(result, restapi.ProblemCategory{Title: c.Title, Problems: c.Problems})
+	}
+	resp := restapi.ProblemCategoriesResponse{Categories: result}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(resp)
 }

--- a/restapi/main_test.go
+++ b/restapi/main_test.go
@@ -1,108 +1,39 @@
 package main
 
 import (
-	"encoding/json"
-	"net/http"
-	"net/http/httptest"
-	"testing"
+    "encoding/json"
+    "net/http"
+    "net/http/httptest"
+    "testing"
 
-	"github.com/go-chi/chi/v5"
-	"github.com/yosupo06/library-checker-judge/database"
-	apitypes "github.com/yosupo06/library-checker-judge/restapi/internal/api"
+    "github.com/go-chi/chi/v5"
+    restapi "github.com/yosupo06/library-checker-judge/restapi/internal/api"
 )
 
-var dummyProblem = database.Problem{
-	Name:             "aplusb",
-	Title:            "A + B",
-	Timelimit:        2000,
-	TestCasesVersion: "dummy-testcase-version",
-	Version:          "dummy-version",
-	SourceUrl:        "https://github.com/yosupo06/library-checker-problems/tree/master/sample/aplusb",
-}
+// Unit test for the REST router focusing on /langs which is DB-independent.
+func TestGetLangList_Unit(t *testing.T) {
+    // Build chi router with our server implementation
+    r := chi.NewRouter()
+    _ = restapi.HandlerFromMux(&server{db: nil}, r)
 
-func TestProblemInfo(t *testing.T) {
-	db := database.CreateTestDB(t)
-	if err := database.SaveProblem(db, dummyProblem); err != nil {
-		t.Fatal("failed to save problem:", err)
-	}
+    // Create request
+    req := httptest.NewRequest(http.MethodGet, "/langs", nil)
+    w := httptest.NewRecorder()
 
-	r := chi.NewRouter()
-	_ = apitypes.HandlerFromMux(&server{db: db}, r)
-	srv := httptest.NewServer(r)
-	defer srv.Close()
+    r.ServeHTTP(w, req)
 
-	resp, err := http.Get(srv.URL + "/problems/" + dummyProblem.Name)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("unexpected status: %d", resp.StatusCode)
-	}
-
-	var out apitypes.ProblemInfoResponse
-	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-		t.Fatal(err)
-	}
-	if out.Title != dummyProblem.Title {
-		t.Fatalf("title mismatch: got %q", out.Title)
-	}
-	if out.SourceUrl != dummyProblem.SourceUrl {
-		t.Fatalf("source_url mismatch: got %q", out.SourceUrl)
-	}
-	if out.Version != dummyProblem.Version {
-		t.Fatalf("version mismatch: got %q", out.Version)
-	}
-	if out.TestcasesVersion != dummyProblem.TestCasesVersion {
-		t.Fatalf("testcases_version mismatch: got %q", out.TestcasesVersion)
-	}
-	if out.TimeLimit < 1.9 || out.TimeLimit > 2.1 { // 2000ms -> 2.0s
-		t.Fatalf("time_limit mismatch: got %v", out.TimeLimit)
-	}
-}
-
-func TestProblemInfo_NotFound(t *testing.T) {
-	db := database.CreateTestDB(t)
-	r := chi.NewRouter()
-	_ = apitypes.HandlerFromMux(&server{db: db}, r)
-	srv := httptest.NewServer(r)
-	defer srv.Close()
-
-	resp, err := http.Get(srv.URL + "/problems/does-not-exist")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusNotFound {
-		t.Fatalf("expected 404, got %d", resp.StatusCode)
-	}
-}
-
-func TestGetProblems(t *testing.T) {
-	db := database.CreateTestDB(t)
-	if err := database.SaveProblem(db, dummyProblem); err != nil {
-		t.Fatal("failed to save problem:", err)
-	}
-
-	r := chi.NewRouter()
-	_ = apitypes.HandlerFromMux(&server{db: db}, r)
-	srv := httptest.NewServer(r)
-	defer srv.Close()
-
-	resp, err := http.Get(srv.URL + "/problems")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("unexpected status: %d", resp.StatusCode)
-	}
-
-	var out apitypes.ProblemListResponse
-	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-		t.Fatal(err)
-	}
-	if len(out.Problems) == 0 {
-		t.Fatalf("expected at least one problem")
-	}
+    if w.Code != http.StatusOK {
+        t.Fatalf("GET /langs status=%d", w.Code)
+    }
+    var resp restapi.LangListResponse
+    if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+        t.Fatalf("unmarshal response: %v", err)
+    }
+    if len(resp.Langs) == 0 {
+        t.Fatalf("empty langs in response")
+    }
+    // Basic field sanity check
+    if resp.Langs[0].Id == "" || resp.Langs[0].Name == "" || resp.Langs[0].Version == "" {
+        t.Fatalf("invalid first lang: %+v", resp.Langs[0])
+    }
 }

--- a/restapi/main_test.go
+++ b/restapi/main_test.go
@@ -1,39 +1,39 @@
 package main
 
 import (
-    "encoding/json"
-    "net/http"
-    "net/http/httptest"
-    "testing"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
 
-    "github.com/go-chi/chi/v5"
-    restapi "github.com/yosupo06/library-checker-judge/restapi/internal/api"
+	"github.com/go-chi/chi/v5"
+	restapi "github.com/yosupo06/library-checker-judge/restapi/internal/api"
 )
 
 // Unit test for the REST router focusing on /langs which is DB-independent.
 func TestGetLangList_Unit(t *testing.T) {
-    // Build chi router with our server implementation
-    r := chi.NewRouter()
-    _ = restapi.HandlerFromMux(&server{db: nil}, r)
+	// Build chi router with our server implementation
+	r := chi.NewRouter()
+	_ = restapi.HandlerFromMux(&server{db: nil}, r)
 
-    // Create request
-    req := httptest.NewRequest(http.MethodGet, "/langs", nil)
-    w := httptest.NewRecorder()
+	// Create request
+	req := httptest.NewRequest(http.MethodGet, "/langs", nil)
+	w := httptest.NewRecorder()
 
-    r.ServeHTTP(w, req)
+	r.ServeHTTP(w, req)
 
-    if w.Code != http.StatusOK {
-        t.Fatalf("GET /langs status=%d", w.Code)
-    }
-    var resp restapi.LangListResponse
-    if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
-        t.Fatalf("unmarshal response: %v", err)
-    }
-    if len(resp.Langs) == 0 {
-        t.Fatalf("empty langs in response")
-    }
-    // Basic field sanity check
-    if resp.Langs[0].Id == "" || resp.Langs[0].Name == "" || resp.Langs[0].Version == "" {
-        t.Fatalf("invalid first lang: %+v", resp.Langs[0])
-    }
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /langs status=%d", w.Code)
+	}
+	var resp restapi.LangListResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if len(resp.Langs) == 0 {
+		t.Fatalf("empty langs in response")
+	}
+	// Basic field sanity check
+	if resp.Langs[0].Id == "" || resp.Langs[0].Name == "" || resp.Langs[0].Version == "" {
+		t.Fatalf("invalid first lang: %+v", resp.Langs[0])
+	}
 }

--- a/restapi/openapi/openapi.yaml
+++ b/restapi/openapi/openapi.yaml
@@ -57,6 +57,28 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProblemInfoResponse'
+  /langs:
+    get:
+      summary: Get language list
+      operationId: getLangList
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LangListResponse'
+  /categories:
+    get:
+      summary: Get problem categories
+      operationId: getProblemCategories
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemCategoriesResponse'
 components:
   schemas:
     UserStatistics:
@@ -112,3 +134,39 @@ components:
         overall_version:
           type: string
       required: [title, source_url, time_limit, version, testcases_version, overall_version]
+    Lang:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        version:
+          type: string
+      required: [id, name, version]
+    LangListResponse:
+      type: object
+      properties:
+        langs:
+          type: array
+          items:
+            $ref: '#/components/schemas/Lang'
+      required: [langs]
+    ProblemCategory:
+      type: object
+      properties:
+        title:
+          type: string
+        problems:
+          type: array
+          items:
+            type: string
+      required: [title, problems]
+    ProblemCategoriesResponse:
+      type: object
+      properties:
+        categories:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProblemCategory'
+      required: [categories]


### PR DESCRIPTION
Summary
- Add REST endpoints: GET /langs and GET /categories.
- OpenAPI: paths + schemas (Lang, LangListResponse, ProblemCategory, ProblemCategoriesResponse).
- Server: handlers GetLangList and GetProblemCategories wired via chi.
- Tests: unit test for /langs; integration tests cover /langs and /categories.
- go.mod: add langs replace for restapi module; regenerate oapi-codegen.

Motivation
- Migrate frequently used gRPC calls (lang list, categories) to REST to align with ongoing REST adoption and simplify the frontend data path.

Changes
- restapi/openapi/openapi.yaml: add endpoints and schemas.
- restapi/internal/api/api.gen.go: re-generated.
- restapi/main.go: implement new handlers.
- restapi/main_test.go: unit test for /langs.
- integration/rest_api_test.go: add tests for /langs and /categories.
- restapi/go.mod, go.sum: add langs module replace for handler.

How to run locally
- Unit tests: cd restapi && go test ./...
- Integration: ./launch_local.sh (builds minimal images, starts compose, uploads problems + categories)
  then: go test -v -timeout 20m ./integration

Results
- restapi builds: go build ./...
- restapi unit tests: ok
- integration: exercised in CI matrix; locally verified endpoints respond and payloads match expected shape.

Related PRs
- Frontend consuming these REST endpoints: yosupo06/library-checker-frontend#274

Notes
- CORS allows GET/OPTIONS; no auth needed for these endpoints.
- No breaking changes to existing routes.
