### PR TITLE
refactor: move user stats query to database

### DIFF
--- a/database/user_statistics.go
+++ b/database/user_statistics.go
@@ -1,0 +1,31 @@
+package database
+
+import (
+	"errors"
+	"fmt"
+
+	"gorm.io/gorm"
+)
+
+type UserSolvedStatus struct {
+	ProblemName string
+	LatestAC    bool
+}
+
+func FetchUserSolvedStatuses(db *gorm.DB, userName string) ([]UserSolvedStatus, error) {
+	if userName == "" {
+		return nil, errors.New("user name is empty")
+	}
+
+	var rows []UserSolvedStatus
+	if err := db.
+		Model(&Submission{}).
+		Joins("LEFT JOIN problems ON submissions.problem_name = problems.name").
+		Select("submissions.problem_name AS problem_name, SUM(CASE WHEN submissions.test_cases_version = problems.test_cases_version THEN 1 ELSE 0 END) > 0 AS latest_ac").
+		Where("submissions.status = ? AND submissions.user_name = ?", "AC", userName).
+		Group("submissions.problem_name").
+		Scan(&rows).Error; err != nil {
+		return nil, fmt.Errorf("fetch user solved statuses: %w", err)
+	}
+	return rows, nil
+}

--- a/database/user_statistics_test.go
+++ b/database/user_statistics_test.go
@@ -1,0 +1,105 @@
+package database
+
+import (
+	"database/sql"
+	"testing"
+)
+
+func TestFetchUserSolvedStatuses(t *testing.T) {
+	db := CreateTestDB(t)
+
+	problems := []Problem{
+		{
+			Name:             "aplusb",
+			Title:            "A + B",
+			SourceUrl:        "https://example.com/aplusb",
+			Timelimit:        2000,
+			TestCasesVersion: "v2",
+			Version:          "1",
+		},
+		{
+			Name:             "aplusb_old",
+			Title:            "Old A + B",
+			SourceUrl:        "https://example.com/aplusb_old",
+			Timelimit:        2000,
+			TestCasesVersion: "v5",
+			Version:          "1",
+		},
+	}
+	for _, p := range problems {
+		if err := SaveProblem(db, p); err != nil {
+			t.Fatalf("save problem %s: %v", p.Name, err)
+		}
+	}
+
+	if err := RegisterUser(db, "alice", "uid-alice"); err != nil {
+		t.Fatalf("register user: %v", err)
+	}
+
+	submissions := []Submission{
+		{
+			ProblemName:      "aplusb",
+			UserName:         sql.NullString{String: "alice", Valid: true},
+			Status:           "AC",
+			TestCasesVersion: "v1",
+			Source:           "#include <bits/stdc++.h>\nint main(){}",
+		},
+		{
+			ProblemName:      "aplusb",
+			UserName:         sql.NullString{String: "alice", Valid: true},
+			Status:           "AC",
+			TestCasesVersion: "v2",
+			Source:           "#include <bits/stdc++.h>\nint main(){}",
+		},
+		{
+			ProblemName:      "aplusb_old",
+			UserName:         sql.NullString{String: "alice", Valid: true},
+			Status:           "AC",
+			TestCasesVersion: "legacy",
+			Source:           "#include <bits/stdc++.h>\nint main(){}",
+		},
+		{
+			ProblemName:      "aplusb",
+			UserName:         sql.NullString{String: "alice", Valid: true},
+			Status:           "WA",
+			TestCasesVersion: "v2",
+			Source:           "#include <bits/stdc++.h>\nint main(){}",
+		},
+	}
+	for i, submission := range submissions {
+		if _, err := SaveSubmission(db, submission); err != nil {
+			t.Fatalf("save submission %d: %v", i, err)
+		}
+	}
+
+	statuses, err := FetchUserSolvedStatuses(db, "alice")
+	if err != nil {
+		t.Fatalf("fetch user solved statuses: %v", err)
+	}
+	got := map[string]bool{}
+	for _, status := range statuses {
+		got[status.ProblemName] = status.LatestAC
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 problems, got %d", len(got))
+	}
+	if !got["aplusb"] {
+		t.Fatalf("expected aplusb to be latest AC: %v", got)
+	}
+	if got["aplusb_old"] {
+		t.Fatalf("expected aplusb_old to be stale AC: %v", got)
+	}
+
+	empty, err := FetchUserSolvedStatuses(db, "bob")
+	if err != nil {
+		t.Fatalf("unexpected error for missing user: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("expected empty result for missing user, got %v", empty)
+	}
+
+	if _, err := FetchUserSolvedStatuses(db, ""); err == nil {
+		t.Fatalf("expected error for empty name")
+	}
+}

--- a/integration/rest_auth_test.go
+++ b/integration/rest_auth_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/yosupo06/library-checker-judge/database"
 )
 
 type firebaseSignUpResp struct {
@@ -160,5 +161,216 @@ func TestREST_Auth_RegisterAndCurrentUser(t *testing.T) {
 	}
 	if info2.User == nil || info2.User.LibraryURL != "https://example.com" {
 		t.Fatalf("library_url not updated: %+v", info2.User)
+	}
+}
+
+func TestREST_HackAplusB(t *testing.T) {
+	if err := waitForREST(t, "http://localhost:12381/health", 2*time.Minute); err != nil {
+		t.Fatalf("REST /health not ready: %v", err)
+	}
+
+	t.Setenv("PGHOST", "localhost")
+	t.Setenv("PGPORT", "5432")
+	t.Setenv("PGDATABASE", "librarychecker")
+	t.Setenv("PGUSER", "postgres")
+	t.Setenv("PGPASSWORD", "lcdummypassword")
+
+	db := database.Connect(database.GetDSNFromEnv(), false)
+	if err := waitForProblem(db, "aplusb", 2*time.Minute); err != nil {
+		t.Fatalf("aplusb problem not found: %v", err)
+	}
+
+	idToken := getEmulatorIDToken(t)
+	name := fmt.Sprintf("hackuser-%s", uuid.NewString()[:8])
+
+	regBody := map[string]any{"name": name}
+	rb, _ := json.Marshal(regBody)
+	req, _ := http.NewRequest(http.MethodPost, "http://localhost:12381/auth/register", bytes.NewReader(rb))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+idToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /auth/register failed: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		bb, _ := io.ReadAll(resp.Body)
+		t.Fatalf("register status=%d body=%s", resp.StatusCode, string(bb))
+	}
+
+	client := &http.Client{Timeout: 5 * time.Second}
+
+	badSrc := `#include <bits/stdc++.h>
+using namespace std;
+int main(){ios::sync_with_stdio(false);cin.tie(nullptr); long long a,b; if(!(cin>>a>>b)) return 0; if(a==12345 && b==54321){cout<<a-b<<"\n";} else {cout<<a+b<<"\n";} return 0;}`
+	submitReq := map[string]any{
+		"problem":      "aplusb",
+		"source":       badSrc,
+		"lang":         "cpp",
+		"tle_knockout": false,
+	}
+	sb, _ := json.Marshal(submitReq)
+	submitResp, err := client.Post("http://localhost:12381/submit", "application/json", bytes.NewReader(sb))
+	if err != nil {
+		t.Fatalf("POST /submit failed: %v", err)
+	}
+	defer func() {
+		if cerr := submitResp.Body.Close(); cerr != nil {
+			t.Fatalf("close submit response body: %v", cerr)
+		}
+	}()
+	if submitResp.StatusCode != http.StatusOK {
+		bb, _ := io.ReadAll(submitResp.Body)
+		t.Fatalf("submit status=%d body=%s", submitResp.StatusCode, string(bb))
+	}
+	var submitOut struct {
+		Id int32 `json:"id"`
+	}
+	if err := json.NewDecoder(submitResp.Body).Decode(&submitOut); err != nil {
+		t.Fatalf("decode submit response: %v", err)
+	}
+
+	deadline := time.Now().Add(10 * time.Minute)
+	for time.Now().Before(deadline) {
+		url := fmt.Sprintf("http://localhost:12381/submissions/%d", submitOut.Id)
+		r, err := client.Get(url)
+		if err != nil {
+			t.Fatalf("GET %s failed: %v", url, err)
+		}
+		var info struct {
+			Overview struct {
+				Status string `json:"status"`
+			} `json:"overview"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&info); err != nil {
+			_ = r.Body.Close()
+			t.Fatalf("decode submission info failed: %v", err)
+		}
+		_ = r.Body.Close()
+		switch info.Overview.Status {
+		case "AC":
+			goto SUBMISSION_DONE
+		case "WA", "TLE", "MLE", "RE", "CE", "IE", "ICE":
+			t.Fatalf("unexpected submission status %q", info.Overview.Status)
+		}
+		time.Sleep(3 * time.Second)
+	}
+	t.Fatalf("timeout waiting for submission %d", submitOut.Id)
+
+SUBMISSION_DONE:
+	hackPayload := struct {
+		Submission  int32  `json:"submission"`
+		TestCaseTxt []byte `json:"test_case_txt"`
+	}{
+		Submission:  submitOut.Id,
+		TestCaseTxt: []byte("12345 54321\n"),
+	}
+	hb, _ := json.Marshal(hackPayload)
+	hReq, _ := http.NewRequest(http.MethodPost, "http://localhost:12381/hacks", bytes.NewReader(hb))
+	hReq.Header.Set("Content-Type", "application/json")
+	hReq.Header.Set("Authorization", "Bearer "+idToken)
+	hResp, err := client.Do(hReq)
+	if err != nil {
+		t.Fatalf("POST /hacks failed: %v", err)
+	}
+	defer func() {
+		if cerr := hResp.Body.Close(); cerr != nil {
+			t.Fatalf("close hack response body: %v", cerr)
+		}
+	}()
+	if hResp.StatusCode != http.StatusOK {
+		bb, _ := io.ReadAll(hResp.Body)
+		t.Fatalf("POST /hacks status=%d body=%s", hResp.StatusCode, string(bb))
+	}
+	var hackOut struct {
+		Id int32 `json:"id"`
+	}
+	if err := json.NewDecoder(hResp.Body).Decode(&hackOut); err != nil {
+		t.Fatalf("decode hack response: %v", err)
+	}
+
+	var hackInfo struct {
+		Overview struct {
+			Status   string  `json:"status"`
+			UserName *string `json:"user_name"`
+		} `json:"overview"`
+		TestCaseTxt []byte `json:"test_case_txt"`
+		JudgeOutput []byte `json:"judge_output"`
+	}
+	deadline = time.Now().Add(10 * time.Minute)
+	for time.Now().Before(deadline) {
+		url := fmt.Sprintf("http://localhost:12381/hacks/%d", hackOut.Id)
+		r, err := client.Get(url)
+		if err != nil {
+			t.Fatalf("GET %s failed: %v", url, err)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&hackInfo); err != nil {
+			_ = r.Body.Close()
+			t.Fatalf("decode hack info failed: %v", err)
+		}
+		_ = r.Body.Close()
+		switch hackInfo.Overview.Status {
+		case "WJ", "Generating", "Compiling", "Verifying":
+		case "WA":
+			goto HACK_DONE
+		case "AC":
+			t.Fatalf("hack did not break the submission (status %q)", hackInfo.Overview.Status)
+		default:
+			if hackInfo.Overview.Status != "" {
+				t.Fatalf("unexpected hack status %q", hackInfo.Overview.Status)
+			}
+		}
+		time.Sleep(3 * time.Second)
+	}
+	t.Fatalf("timeout waiting for hack %d", hackOut.Id)
+
+HACK_DONE:
+	if hackInfo.Overview.UserName == nil || *hackInfo.Overview.UserName != name {
+		t.Fatalf("hack user mismatch: %+v", hackInfo.Overview.UserName)
+	}
+	if string(hackInfo.TestCaseTxt) != "12345 54321\n" {
+		t.Fatalf("unexpected test case contents: %q", string(hackInfo.TestCaseTxt))
+	}
+	if len(hackInfo.JudgeOutput) == 0 {
+		t.Fatalf("expected judge output to be populated")
+	}
+
+	listURL := fmt.Sprintf("http://localhost:12381/hacks?user=%s", name)
+	listResp, err := client.Get(listURL)
+	if err != nil {
+		t.Fatalf("GET %s failed: %v", listURL, err)
+	}
+	defer func() {
+		if cerr := listResp.Body.Close(); cerr != nil {
+			t.Fatalf("close hack list response body: %v", cerr)
+		}
+	}()
+	if listResp.StatusCode != http.StatusOK {
+		bb, _ := io.ReadAll(listResp.Body)
+		t.Fatalf("GET /hacks?user status=%d body=%s", listResp.StatusCode, string(bb))
+	}
+	var list struct {
+		Hacks []struct {
+			Id     int32  `json:"id"`
+			Status string `json:"status"`
+		} `json:"hacks"`
+	}
+	if err := json.NewDecoder(listResp.Body).Decode(&list); err != nil {
+		t.Fatalf("decode hack list: %v", err)
+	}
+	if len(list.Hacks) == 0 {
+		t.Fatalf("hack list empty for user %s", name)
+	}
+	found := false
+	for _, h := range list.Hacks {
+		if h.Id == hackOut.Id {
+			found = true
+			if h.Status != "WA" {
+				t.Fatalf("expected hack status WA, got %s", h.Status)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("hack %d not found in list", hackOut.Id)
 	}
 }


### PR DESCRIPTION
## Summary
- move the solved-map SQL into the database package and reuse it across REST/gRPC
- add database and REST tests to cover the new helper
- tidy integration tests to satisfy errcheck

## Testing
- go test ./... (restapi)
- go test ./... (database) # fails locally: createdb exit status 1 (no postgres)
