### PR TITLE
chore(langs): trim haskell/java images

### DIFF
--- a/langs/Dockerfile.HASKELL
+++ b/langs/Dockerfile.HASKELL
@@ -43,7 +43,12 @@ RUN cabal update && cabal install --lib \
     vector-0.13.0.0 \
     vector-algorithms-0.9.0.1 \
     vector-stream-0.1.0.0 \
-    vector-th-unbox-0.2.2
+    vector-th-unbox-0.2.2 \
+ && rm -rf /root/.cabal/logs \
+           /root/.cabal/packages \
+           /root/.cache \
+           /root/.ghcup/cache \
+           /root/.ghcup/logs
 
 COPY --from=init-builder /library-checker-init/target/x86_64-unknown-linux-musl/release/library-checker-init /usr/bin
 

--- a/langs/Dockerfile.JAVA
+++ b/langs/Dockerfile.JAVA
@@ -3,7 +3,7 @@ WORKDIR /library-checker-init
 COPY init /library-checker-init
 RUN cargo build --release --target=x86_64-unknown-linux-musl
 
-FROM openjdk:17
+FROM eclipse-temurin:17-jdk-alpine
 
 COPY --from=init-builder /library-checker-init/target/x86_64-unknown-linux-musl/release/library-checker-init /usr/bin
 


### PR DESCRIPTION
## Summary
- remove cabal/ghcup caches in haskell image to reduce final layer size
- switch java image to eclipse temurin alpine base to shrink footprint

## Testing
- not run (image build is heavyweight; rely on CI size-report job)