### PR TITLE
feat(metrics): autoscale judges by queue depth

### DIFF
--- a/terraform/cloudfunction.tf
+++ b/terraform/cloudfunction.tf
@@ -1,7 +1,12 @@
 resource "google_cloud_run_v2_service" "queue_metrics" {
-  name     = "queue-metrics"
-  location = local.region
-  ingress  = "INGRESS_TRAFFIC_ALL"
+  name                = "queue-metrics"
+  location            = local.region
+  ingress             = "INGRESS_TRAFFIC_ALL"
+  deletion_protection = false
+  depends_on = [
+    google_project_iam_member.sa_role,
+    google_service_account_iam_member.queue_metrics_invoker_token,
+  ]
 
   template {
     scaling {


### PR DESCRIPTION
## Summary
- add autoscaling policy for the judge MIG using the new queue depth metric
- deploy the metric emitter to Cloud Run (with deterministic project ID detection)
- wire CI to build/push the metrics container, add the necessary service accounts/outputs
- allow Terraform to recreate the Cloud Run job by disabling deletion protection and ordering IAM dependencies

## Testing
- GOWORK=off go build ./... # cloudrun/taskqueue-metrics
- terraform fmt && terraform validate
