### PR TITLE
Use c2d-standard-8 for packer builds

### DIFF
--- a/packer/base/build.pkr.hcl
+++ b/packer/base/build.pkr.hcl
@@ -21,7 +21,7 @@ source "googlecompute" "judge" {
   zone = "us-east1-b"
   network = "main"
   subnetwork = "main"
-  machine_type = "c2-standard-4"
+  machine_type = "c2d-standard-8"
   disk_size = 50
   ssh_username = "ubuntu"
   temporary_key_pair_type = "ed25519"

--- a/packer/judge/build.pkr.hcl
+++ b/packer/judge/build.pkr.hcl
@@ -59,7 +59,7 @@ source "googlecompute" "judge" {
   zone = "us-east1-b"
   network = "main"
   subnetwork = "main"
-  machine_type = "c2-standard-4"
+  machine_type = "c2d-standard-8"
   disk_size = 50
   ssh_username = "ubuntu"
   temporary_key_pair_type = "ed25519"


### PR DESCRIPTION
## Summary
- update the base image Packer template to build on `c2d-standard-8`
- align the judge image Packer template with the same `c2d-standard-8` machine type

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d08c54b4348321a59d3e8e4641211e