### PR TITLE
Run executor language tests without build tags

### DIFF
--- a/executor/langs_aplusb_test.go
+++ b/executor/langs_aplusb_test.go
@@ -1,6 +1,3 @@
-//go:build langs_all
-// +build langs_all
-
 package executor
 
 import (


### PR DESCRIPTION
## Summary
- remove the `langs_all` build constraint so the executor language conformance test always runs

## Testing
- `go test ./...` *(fails: executor tests require Docker which is not available in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d09e645f0083218f6f1c48fdefa73a