### PR TITLE
Add scheduled workflow to prune old judge images

### DIFF
--- a/.github/workflows/judge-image-prune.yml
+++ b/.github/workflows/judge-image-prune.yml
@@ -1,0 +1,77 @@
+name: Prune Judge Images
+
+on:
+  schedule:
+    - cron: '0 18 * * *'
+  workflow_dispatch:
+    inputs:
+      env:
+        description: 'Environment to prune'
+        type: choice
+        default: all
+        options:
+          - all
+          - dev
+          - prod
+      dry-run:
+        description: 'Only print images that would be deleted'
+        type: boolean
+        default: false
+
+jobs:
+  prune:
+    name: Prune judge images (${{ matrix.env }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        env: [dev, prod]
+    if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.env == 'all' || github.event.inputs.env == matrix.env }}
+    permissions:
+      contents: read
+      id-token: write
+    concurrency:
+      group: judge-image-prune-${{ matrix.env }}
+      cancel-in-progress: false
+    env:
+      TF_CLOUD_ORGANIZATION: yosupo06-org
+      TF_WORKSPACE: ${{ format('{0}-library-checker', matrix.env) }}
+      PROJECT_ID: ${{ format('{0}-library-checker-project', matrix.env) }}
+      IMAGE_FAMILY: v3-judge-image
+      KEEP_COUNT: '10'
+      MIN_AGE_DAYS: '14'
+      DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+
+      - run: terraform init
+        working-directory: ./terraform
+
+      - id: tf-output
+        run: terraform output --json
+        working-directory: ./terraform
+
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ fromJson(steps.tf-output.outputs.stdout).gh_provider_id.value }}
+          service_account: ${{ fromJson(steps.tf-output.outputs.stdout).judge_deployer_sa_email.value }}
+          token_format: access_token
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Prune images
+        run: |
+          ARGS=(
+            --project "$PROJECT_ID"
+            --family "$IMAGE_FAMILY"
+            --keep "$KEEP_COUNT"
+            --min-age-days "$MIN_AGE_DAYS"
+          )
+          if [[ "${DRY_RUN}" == "true" ]]; then
+            ARGS+=(--dry-run)
+          fi
+          ./scripts/prune_gce_images.sh "${ARGS[@]}"

--- a/scripts/prune_gce_images.sh
+++ b/scripts/prune_gce_images.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: prune_gce_images.sh --project <PROJECT_ID> --family <IMAGE_FAMILY> [options]
+
+Options:
+  --keep <N>           Number of latest images to keep (default: 10)
+  --min-age-days <N>   Minimum age in days before an image can be deleted (default: 14)
+  --dry-run            Only print the images that would be deleted
+  -h, --help           Show this help message
+USAGE
+}
+
+PROJECT=""
+FAMILY=""
+KEEP=10
+MIN_AGE_DAYS=14
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project)
+      PROJECT="$2"
+      shift 2
+      ;;
+    --family)
+      FAMILY="$2"
+      shift 2
+      ;;
+    --keep)
+      KEEP="$2"
+      shift 2
+      ;;
+    --min-age-days)
+      MIN_AGE_DAYS="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$PROJECT" || -z "$FAMILY" ]]; then
+  echo "--project and --family are required" >&2
+  usage >&2
+  exit 1
+fi
+
+if ! [[ "$KEEP" =~ ^[0-9]+$ && "$MIN_AGE_DAYS" =~ ^[0-9]+$ ]]; then
+  echo "--keep and --min-age-days must be non-negative integers" >&2
+  exit 1
+fi
+
+now_epoch=$(date +%s)
+min_age_seconds=$(( MIN_AGE_DAYS * 24 * 60 * 60 ))
+
+mapfile -t images < <(gcloud compute images list \
+  --project="$PROJECT" \
+  --filter="family=$FAMILY" \
+  --no-standard-images \
+  --format="value(name,creationTimestamp)" \
+  --sort-by="~creationTimestamp")
+
+total=${#images[@]}
+if (( total == 0 )); then
+  echo "No images found for family '$FAMILY' in project '$PROJECT'."
+  exit 0
+fi
+
+echo "Found $total images for family '$FAMILY' in project '$PROJECT'. Keeping the latest $KEEP images."
+
+if (( total <= KEEP )); then
+  echo "Nothing to prune."
+  exit 0
+fi
+
+pruned_any=false
+for (( i=KEEP; i<total; i++ )); do
+  entry=${images[$i]}
+  name=${entry%% *}
+  timestamp=${entry#* }
+  if [[ -z "$name" || -z "$timestamp" ]]; then
+    continue
+  fi
+
+  image_epoch=$(date --date="$timestamp" +%s)
+  age_seconds=$(( now_epoch - image_epoch ))
+
+  if (( age_seconds < min_age_seconds )); then
+    echo "Skipping $name (only $(( age_seconds / 86400 )) days old)."
+    continue
+  fi
+
+  pruned_any=true
+  if [[ "$DRY_RUN" == true ]]; then
+    echo "[DRY RUN] Would delete image $name"
+  else
+    echo "Deleting image $name"
+    gcloud compute images delete "$name" --project="$PROJECT" --quiet
+  fi
+done
+
+if [[ "$DRY_RUN" == true ]]; then
+  echo "Dry run completed."
+elif [[ "$pruned_any" == false ]]; then
+  echo "No images matched pruning criteria."
+fi


### PR DESCRIPTION
## Summary
- add a reusable pruning script that deletes stale GCE judge images beyond a retention window
- schedule a GitHub Actions workflow that authenticates with GCP and runs the pruning script for dev/prod, with manual dry-run support

## Testing
- bash -n scripts/prune_gce_images.sh

------
https://chatgpt.com/codex/tasks/task_e_68d08c993b54832192182e162e01e276