### PR TITLE
fix(judge): use local storage emulator in launch script

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Judge server / API server のソースコードです
 ```
 
 APIサーバー(localhost:50051)とSQL(PostgreSQL)がDocker Composeで立ち上がり、`aplusb, unionfind`がデプロイされる。
+問題データのアップロード先にはローカルの fake GCS (`http://localhost:4443`) を使うため、Google Cloud の認証情報や権限は不要です。
 
 言語イメージ（judge が使用）は起動前にビルドが必要です。`./launch_local.sh` は既定で最小セット（gcc + python3）をビルドしてから起動します。全言語や任意サブセットをビルドしたい場合は `LC_LANGS` を指定してください。
 
@@ -31,6 +32,15 @@ LC_LANGS=all ./launch_local.sh
 
 # 任意サブセット
 LC_LANGS="gcc python3 rust" ./launch_local.sh
+```
+
+fake GCS の接続先やバケット名を変更する場合は、ホスト側から見える値を指定してください。
+
+```sh
+LOCAL_STORAGE_EMULATOR_HOST=http://localhost:4443 \
+LOCAL_STORAGE_PRIVATE_BUCKET=testcase \
+LOCAL_STORAGE_PUBLIC_BUCKET=testcase-public \
+./launch_local.sh
 ```
 
 ### 動作確認

--- a/launch_local.sh
+++ b/launch_local.sh
@@ -1,4 +1,24 @@
-set -e
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+cd "$SCRIPT_DIR"
+
+LOCAL_STORAGE_EMULATOR_HOST=${LOCAL_STORAGE_EMULATOR_HOST:-http://localhost:4443}
+LOCAL_STORAGE_PROJECT_ID=${LOCAL_STORAGE_PROJECT_ID:-dev-library-checker-project}
+LOCAL_STORAGE_PRIVATE_BUCKET=${LOCAL_STORAGE_PRIVATE_BUCKET:-testcase}
+LOCAL_STORAGE_PUBLIC_BUCKET=${LOCAL_STORAGE_PUBLIC_BUCKET:-testcase-public}
+
+run_local_uploader() {
+    (
+        cd uploader
+        STORAGE_EMULATOR_HOST="$LOCAL_STORAGE_EMULATOR_HOST" \
+        STORAGE_PROJECT_ID="$LOCAL_STORAGE_PROJECT_ID" \
+        STORAGE_PRIVATE_BUCKET="$LOCAL_STORAGE_PRIVATE_BUCKET" \
+        STORAGE_PUBLIC_BUCKET="$LOCAL_STORAGE_PUBLIC_BUCKET" \
+            "$@"
+    )
+}
 
 docker --version
 
@@ -13,9 +33,9 @@ docker compose down -v
 docker compose up -d --build --wait
 
 # deploy sample problems
-SCRIPT_DIR=$(cd $(dirname $0) && pwd)
-PROBLEMS_PATH=$(realpath $SCRIPT_DIR/../library-checker-problems)
-(cd uploader && go run ./problems -dir $PROBLEMS_PATH $PROBLEMS_PATH/sample/aplusb/info.toml $PROBLEMS_PATH/data_structure/unionfind/info.toml)
+PROBLEMS_PATH=$(realpath "$SCRIPT_DIR/../library-checker-problems")
+echo "Using local storage emulator: $LOCAL_STORAGE_EMULATOR_HOST"
+run_local_uploader go run ./problems -dir "$PROBLEMS_PATH" "$PROBLEMS_PATH/sample/aplusb/info.toml" "$PROBLEMS_PATH/data_structure/unionfind/info.toml"
 
 # upload categories from categories.toml
-(cd uploader && go run ./categories -dir $PROBLEMS_PATH)
+run_local_uploader go run ./categories -dir "$PROBLEMS_PATH"


### PR DESCRIPTION
## Summary
- Make `launch_local.sh` run from its own directory and fail on unset variables/pipeline errors
- Pass local fake GCS settings explicitly to uploader commands so sample problem deployment does not use real GCS credentials
- Document the local fake GCS behavior and override variables in README

## Test
- `bash -n launch_local.sh`