### PR TITLE
feat(judge): add remaining REST endpoints

### DIFF
--- a/restapi/handlers_auth.go
+++ b/restapi/handlers_auth.go
@@ -63,31 +63,6 @@ func (s *server) PatchCurrentUserInfo(ctx context.Context, request restapi.Patch
 	return restapi.PatchCurrentUserInfo200JSONResponse(restapi.ChangeCurrentUserInfoResponse{}), nil
 }
 
-// PatchUserInfo handles PATCH /users/{name}
-func (s *server) PatchUserInfo(ctx context.Context, request restapi.PatchUserInfoRequestObject) (restapi.PatchUserInfoResponseObject, error) {
-	if request.Body == nil || request.Body.User.Name == "" {
-		return nil, newHTTPError(http.StatusBadRequest, "invalid request")
-	}
-	currentUser, err := s.currentUserFromContext(ctx)
-	if err != nil || currentUser == nil {
-		return nil, newHTTPError(http.StatusUnauthorized, "unauthorized")
-	}
-	if request.Name != currentUser.Name || request.Body.User.Name != currentUser.Name {
-		return nil, newHTTPError(http.StatusForbidden, "permission denied")
-	}
-
-	user := database.User{
-		Name:        currentUser.Name,
-		UID:         currentUser.UID,
-		LibraryURL:  request.Body.User.LibraryUrl,
-		IsDeveloper: request.Body.User.IsDeveloper,
-	}
-	if err := s.updateUser(s.db, user); err != nil {
-		return nil, newHTTPError(http.StatusBadRequest, "update failed")
-	}
-	return restapi.PatchUserInfo200JSONResponse(restapi.ChangeUserInfoResponse{}), nil
-}
-
 // GetUserInfo handles GET /users/{name}
 func (s *server) GetUserInfo(_ context.Context, request restapi.GetUserInfoRequestObject) (restapi.GetUserInfoResponseObject, error) {
 	if request.Name == "" {

--- a/restapi/handlers_auth.go
+++ b/restapi/handlers_auth.go
@@ -63,6 +63,31 @@ func (s *server) PatchCurrentUserInfo(ctx context.Context, request restapi.Patch
 	return restapi.PatchCurrentUserInfo200JSONResponse(restapi.ChangeCurrentUserInfoResponse{}), nil
 }
 
+// PatchUserInfo handles PATCH /users/{name}
+func (s *server) PatchUserInfo(ctx context.Context, request restapi.PatchUserInfoRequestObject) (restapi.PatchUserInfoResponseObject, error) {
+	if request.Body == nil || request.Body.User.Name == "" {
+		return nil, newHTTPError(http.StatusBadRequest, "invalid request")
+	}
+	currentUser, err := s.currentUserFromContext(ctx)
+	if err != nil || currentUser == nil {
+		return nil, newHTTPError(http.StatusUnauthorized, "unauthorized")
+	}
+	if request.Name != currentUser.Name || request.Body.User.Name != currentUser.Name {
+		return nil, newHTTPError(http.StatusForbidden, "permission denied")
+	}
+
+	user := database.User{
+		Name:        currentUser.Name,
+		UID:         currentUser.UID,
+		LibraryURL:  request.Body.User.LibraryUrl,
+		IsDeveloper: request.Body.User.IsDeveloper,
+	}
+	if err := s.updateUser(s.db, user); err != nil {
+		return nil, newHTTPError(http.StatusBadRequest, "update failed")
+	}
+	return restapi.PatchUserInfo200JSONResponse(restapi.ChangeUserInfoResponse{}), nil
+}
+
 // GetUserInfo handles GET /users/{name}
 func (s *server) GetUserInfo(_ context.Context, request restapi.GetUserInfoRequestObject) (restapi.GetUserInfoResponseObject, error) {
 	if request.Name == "" {
@@ -109,4 +134,12 @@ func fetchUserStatisticsREST(db *gorm.DB, userName string) (map[string]restapi.S
 		}
 	}
 	return stats, nil
+}
+
+func (s *server) currentUserFromContext(ctx context.Context) (*database.User, error) {
+	uid, err := s.uidFromContext(ctx)
+	if err != nil || uid == "" {
+		return nil, err
+	}
+	return database.FetchUserFromUID(s.db, uid)
 }

--- a/restapi/handlers_auth_test.go
+++ b/restapi/handlers_auth_test.go
@@ -96,69 +96,6 @@ func TestPatchCurrentUserInfo_Succeeds(t *testing.T) {
 	}
 }
 
-func TestPatchUserInfo_SucceedsForCurrentUser(t *testing.T) {
-	db := setupTestDB(t)
-	if err := database.RegisterUser(db, "alice", "uid-123"); err != nil {
-		t.Fatalf("register user: %v", err)
-	}
-	var captured database.User
-	called := false
-	s := &server{
-		db:         db,
-		authClient: fakeAuthClient{uid: "uid-123"},
-		updateUserFn: func(_ *gorm.DB, u database.User) error {
-			called = true
-			captured = u
-			return nil
-		},
-	}
-
-	body := `{"user":{"name":"alice","library_url":"https://example.com","is_developer":false}}`
-	req := httptest.NewRequest(http.MethodPatch, "/users/alice", bytes.NewReader([]byte(body)))
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer token")
-	w := httptest.NewRecorder()
-	r := chi.NewRouter()
-	_ = restapi.HandlerFromMux(newRESTHandler(s), r)
-	r.ServeHTTP(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("PATCH /users/alice status=%d body=%s", w.Code, w.Body.String())
-	}
-	if !called {
-		t.Fatalf("updateUser was not invoked")
-	}
-	if captured.UID != "uid-123" {
-		t.Fatalf("expected UID uid-123, got %q", captured.UID)
-	}
-	if captured.LibraryURL != "https://example.com" {
-		t.Fatalf("library url not propagated: %q", captured.LibraryURL)
-	}
-}
-
-func TestPatchUserInfo_RejectsOtherUser(t *testing.T) {
-	db := setupTestDB(t)
-	if err := database.RegisterUser(db, "alice", "uid-123"); err != nil {
-		t.Fatalf("register alice: %v", err)
-	}
-	if err := database.RegisterUser(db, "bob", "uid-456"); err != nil {
-		t.Fatalf("register bob: %v", err)
-	}
-
-	body := `{"user":{"name":"bob","library_url":"https://example.com","is_developer":false}}`
-	req := httptest.NewRequest(http.MethodPatch, "/users/bob", bytes.NewReader([]byte(body)))
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer token")
-	w := httptest.NewRecorder()
-	r := chi.NewRouter()
-	_ = restapi.HandlerFromMux(newRESTHandler(&server{db: db, authClient: fakeAuthClient{uid: "uid-123"}}), r)
-	r.ServeHTTP(w, req)
-
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("expected 403, got %d body=%s", w.Code, w.Body.String())
-	}
-}
-
 func TestGetUserInfo_WithoutStatistics(t *testing.T) {
 	db := setupTestDB(t)
 	if err := database.RegisterUser(db, "alice", "uid-123"); err != nil {

--- a/restapi/handlers_auth_test.go
+++ b/restapi/handlers_auth_test.go
@@ -96,6 +96,69 @@ func TestPatchCurrentUserInfo_Succeeds(t *testing.T) {
 	}
 }
 
+func TestPatchUserInfo_SucceedsForCurrentUser(t *testing.T) {
+	db := setupTestDB(t)
+	if err := database.RegisterUser(db, "alice", "uid-123"); err != nil {
+		t.Fatalf("register user: %v", err)
+	}
+	var captured database.User
+	called := false
+	s := &server{
+		db:         db,
+		authClient: fakeAuthClient{uid: "uid-123"},
+		updateUserFn: func(_ *gorm.DB, u database.User) error {
+			called = true
+			captured = u
+			return nil
+		},
+	}
+
+	body := `{"user":{"name":"alice","library_url":"https://example.com","is_developer":false}}`
+	req := httptest.NewRequest(http.MethodPatch, "/users/alice", bytes.NewReader([]byte(body)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer token")
+	w := httptest.NewRecorder()
+	r := chi.NewRouter()
+	_ = restapi.HandlerFromMux(newRESTHandler(s), r)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("PATCH /users/alice status=%d body=%s", w.Code, w.Body.String())
+	}
+	if !called {
+		t.Fatalf("updateUser was not invoked")
+	}
+	if captured.UID != "uid-123" {
+		t.Fatalf("expected UID uid-123, got %q", captured.UID)
+	}
+	if captured.LibraryURL != "https://example.com" {
+		t.Fatalf("library url not propagated: %q", captured.LibraryURL)
+	}
+}
+
+func TestPatchUserInfo_RejectsOtherUser(t *testing.T) {
+	db := setupTestDB(t)
+	if err := database.RegisterUser(db, "alice", "uid-123"); err != nil {
+		t.Fatalf("register alice: %v", err)
+	}
+	if err := database.RegisterUser(db, "bob", "uid-456"); err != nil {
+		t.Fatalf("register bob: %v", err)
+	}
+
+	body := `{"user":{"name":"bob","library_url":"https://example.com","is_developer":false}}`
+	req := httptest.NewRequest(http.MethodPatch, "/users/bob", bytes.NewReader([]byte(body)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer token")
+	w := httptest.NewRecorder()
+	r := chi.NewRouter()
+	_ = restapi.HandlerFromMux(newRESTHandler(&server{db: db, authClient: fakeAuthClient{uid: "uid-123"}}), r)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
 func TestGetUserInfo_WithoutStatistics(t *testing.T) {
 	db := setupTestDB(t)
 	if err := database.RegisterUser(db, "alice", "uid-123"); err != nil {

--- a/restapi/handlers_meta.go
+++ b/restapi/handlers_meta.go
@@ -32,3 +32,21 @@ func (s *server) GetProblemCategories(_ context.Context, _ restapi.GetProblemCat
 	resp := restapi.ProblemCategoriesResponse{Categories: result}
 	return restapi.GetProblemCategories200JSONResponse(resp), nil
 }
+
+// GetMonitoring handles GET /monitoring
+func (s *server) GetMonitoring(_ context.Context, _ restapi.GetMonitoringRequestObject) (restapi.GetMonitoringResponseObject, error) {
+	data, err := database.FetchMonitoringData(s.db)
+	if err != nil {
+		return nil, newHTTPError(http.StatusInternalServerError, "failed to fetch monitoring data")
+	}
+	resp := restapi.MonitoringResponse{
+		TotalUsers:       int32(data.TotalUsers),
+		TotalSubmissions: int32(data.TotalSubmissions),
+		TaskQueue: restapi.TaskQueueInfo{
+			PendingTasks: int32(data.TaskQueue.PendingTasks),
+			RunningTasks: int32(data.TaskQueue.RunningTasks),
+			TotalTasks:   int32(data.TaskQueue.TotalTasks),
+		},
+	}
+	return restapi.GetMonitoring200JSONResponse(resp), nil
+}

--- a/restapi/handlers_submissions.go
+++ b/restapi/handlers_submissions.go
@@ -70,7 +70,7 @@ func (s *server) PostSubmit(ctx context.Context, request restapi.PostSubmitReque
 }
 
 // GetSubmissionInfo handles GET /submissions/{id}
-func (s *server) GetSubmissionInfo(_ context.Context, request restapi.GetSubmissionInfoRequestObject) (restapi.GetSubmissionInfoResponseObject, error) {
+func (s *server) GetSubmissionInfo(ctx context.Context, request restapi.GetSubmissionInfoRequestObject) (restapi.GetSubmissionInfoResponseObject, error) {
 	sub, err := database.FetchSubmission(s.db, request.Id)
 	if err != nil {
 		if err == database.ErrNotExist {
@@ -136,10 +136,35 @@ func (s *server) GetSubmissionInfo(_ context.Context, request restapi.GetSubmiss
 		CompileError: compileErr,
 		CanRejudge:   false,
 	}
+	if currentUser, err := s.currentUserFromContext(ctx); err == nil && currentUser != nil {
+		resp.CanRejudge = canRejudgeREST(*currentUser, sub)
+	}
 	if len(cr) > 0 {
 		resp.CaseResults = &cr
 	}
 	return restapi.GetSubmissionInfo200JSONResponse(resp), nil
+}
+
+// PostRejudge handles POST /submissions/{id}/rejudge
+func (s *server) PostRejudge(ctx context.Context, request restapi.PostRejudgeRequestObject) (restapi.PostRejudgeResponseObject, error) {
+	currentUser, err := s.currentUserFromContext(ctx)
+	if err != nil || currentUser == nil {
+		return nil, newHTTPError(http.StatusUnauthorized, "unauthorized")
+	}
+	sub, err := database.FetchSubmission(s.db, request.Id)
+	if err != nil {
+		if err == database.ErrNotExist {
+			return nil, newHTTPError(http.StatusNotFound, "not found")
+		}
+		return nil, newHTTPError(http.StatusInternalServerError, "failed to fetch submission")
+	}
+	if !canRejudgeREST(*currentUser, sub) {
+		return nil, newHTTPError(http.StatusForbidden, "permission denied")
+	}
+	if err := database.PushSubmissionTask(s.db, database.SubmissionData{ID: request.Id, TleKnockout: false}, 40); err != nil {
+		return nil, newHTTPError(http.StatusInternalServerError, "rejudge failed")
+	}
+	return restapi.PostRejudge200JSONResponse(restapi.RejudgeResponse{}), nil
 }
 
 // GetSubmissionList handles GET /submissions
@@ -214,4 +239,14 @@ func deref[T any](p *T) T {
 		return zero
 	}
 	return *p
+}
+
+func canRejudgeREST(currentUser database.User, submission database.Submission) bool {
+	if currentUser.Name == "" {
+		return false
+	}
+	if submission.UserName.Valid && currentUser.Name == submission.UserName.String {
+		return true
+	}
+	return submission.TestCasesVersion != submission.Problem.TestCasesVersion && submission.Status == "AC"
 }

--- a/restapi/handlers_submissions_test.go
+++ b/restapi/handlers_submissions_test.go
@@ -155,6 +155,152 @@ func TestPostRejudge_AllowsSubmissionOwner(t *testing.T) {
 	}
 }
 
+func TestGetSubmissionInfo_CanRejudgeOwner(t *testing.T) {
+	db := setupTestDB(t)
+	problem := database.Problem{
+		Name:             "aplusb-rejudge-owner",
+		Title:            "A + B",
+		SourceUrl:        "https://example.com/aplusb",
+		Timelimit:        2000,
+		TestCasesVersion: "v1",
+		Version:          "1",
+		OverallVersion:   "1",
+	}
+	if err := database.SaveProblem(db, problem); err != nil {
+		t.Fatalf("save problem: %v", err)
+	}
+	if err := database.RegisterUser(db, "alice", "uid-owner"); err != nil {
+		t.Fatalf("register user: %v", err)
+	}
+	id, err := database.SaveSubmission(db, database.Submission{
+		ProblemName:      problem.Name,
+		Lang:             "cpp",
+		Status:           "AC",
+		Source:           "#include <bits/stdc++.h>\nint main(){return 0;}",
+		TestCasesVersion: "v1",
+		MaxTime:          1,
+		MaxMemory:        1,
+		UserName:         sql.NullString{String: "alice", Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("save submission: %v", err)
+	}
+
+	s := &server{db: db, authClient: fakeAuthClient{uid: "uid-owner"}}
+	req := httptest.NewRequest(http.MethodGet, "/submissions/1", nil)
+	req.Header.Set("Authorization", "Bearer token")
+	ctx := withHTTPRequest(context.Background(), req)
+	respObj, err := s.GetSubmissionInfo(ctx, restapi.GetSubmissionInfoRequestObject{Id: id})
+	if err != nil {
+		t.Fatalf("GetSubmissionInfo returned error: %v", err)
+	}
+	resp, ok := respObj.(restapi.GetSubmissionInfo200JSONResponse)
+	if !ok {
+		t.Fatalf("unexpected response type %T", respObj)
+	}
+	if !resp.CanRejudge {
+		t.Fatalf("expected owner can_rejudge=true")
+	}
+}
+
+func TestGetSubmissionInfo_CanRejudgeOldAcceptedSubmission(t *testing.T) {
+	db := setupTestDB(t)
+	problem := database.Problem{
+		Name:             "aplusb-rejudge-old-ac",
+		Title:            "A + B",
+		SourceUrl:        "https://example.com/aplusb",
+		Timelimit:        2000,
+		TestCasesVersion: "v2",
+		Version:          "1",
+		OverallVersion:   "1",
+	}
+	if err := database.SaveProblem(db, problem); err != nil {
+		t.Fatalf("save problem: %v", err)
+	}
+	if err := database.RegisterUser(db, "alice", "uid-alice"); err != nil {
+		t.Fatalf("register alice: %v", err)
+	}
+	if err := database.RegisterUser(db, "bob", "uid-bob"); err != nil {
+		t.Fatalf("register bob: %v", err)
+	}
+	id, err := database.SaveSubmission(db, database.Submission{
+		ProblemName:      problem.Name,
+		Lang:             "cpp",
+		Status:           "AC",
+		Source:           "#include <bits/stdc++.h>\nint main(){return 0;}",
+		TestCasesVersion: "v1",
+		MaxTime:          1,
+		MaxMemory:        1,
+		UserName:         sql.NullString{String: "alice", Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("save submission: %v", err)
+	}
+
+	s := &server{db: db, authClient: fakeAuthClient{uid: "uid-bob"}}
+	req := httptest.NewRequest(http.MethodGet, "/submissions/1", nil)
+	req.Header.Set("Authorization", "Bearer token")
+	ctx := withHTTPRequest(context.Background(), req)
+	respObj, err := s.GetSubmissionInfo(ctx, restapi.GetSubmissionInfoRequestObject{Id: id})
+	if err != nil {
+		t.Fatalf("GetSubmissionInfo returned error: %v", err)
+	}
+	resp, ok := respObj.(restapi.GetSubmissionInfo200JSONResponse)
+	if !ok {
+		t.Fatalf("unexpected response type %T", respObj)
+	}
+	if !resp.CanRejudge {
+		t.Fatalf("expected old AC submission can_rejudge=true for non-owner")
+	}
+}
+
+func TestPostRejudge_RejectsNonOwnerWithoutEligibility(t *testing.T) {
+	db := setupTestDB(t)
+	problem := database.Problem{
+		Name:             "aplusb-rejudge-forbidden",
+		Title:            "A + B",
+		SourceUrl:        "https://example.com/aplusb",
+		Timelimit:        2000,
+		TestCasesVersion: "v1",
+		Version:          "1",
+		OverallVersion:   "1",
+	}
+	if err := database.SaveProblem(db, problem); err != nil {
+		t.Fatalf("save problem: %v", err)
+	}
+	if err := database.RegisterUser(db, "alice", "uid-alice"); err != nil {
+		t.Fatalf("register alice: %v", err)
+	}
+	if err := database.RegisterUser(db, "bob", "uid-bob"); err != nil {
+		t.Fatalf("register bob: %v", err)
+	}
+	id, err := database.SaveSubmission(db, database.Submission{
+		ProblemName:      problem.Name,
+		Lang:             "cpp",
+		Status:           "AC",
+		Source:           "#include <bits/stdc++.h>\nint main(){return 0;}",
+		TestCasesVersion: "v1",
+		MaxTime:          1,
+		MaxMemory:        1,
+		UserName:         sql.NullString{String: "alice", Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("save submission: %v", err)
+	}
+
+	s := &server{db: db, authClient: fakeAuthClient{uid: "uid-bob"}}
+	req := httptest.NewRequest(http.MethodPost, "/submissions/1/rejudge", nil)
+	req.Header.Set("Authorization", "Bearer token")
+	ctx := withHTTPRequest(context.Background(), req)
+	_, err = s.PostRejudge(ctx, restapi.PostRejudgeRequestObject{Id: id})
+	if err == nil {
+		t.Fatalf("expected forbidden error")
+	}
+	if httpErr, ok := getHTTPError(err); !ok || httpErr.Status != http.StatusForbidden {
+		t.Fatalf("expected 403, got %v", err)
+	}
+}
+
 func TestPostRejudge_RejectsAnonymous(t *testing.T) {
 	db := setupTestDB(t)
 	s := &server{db: db}

--- a/restapi/handlers_submissions_test.go
+++ b/restapi/handlers_submissions_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -107,5 +108,63 @@ func TestPostSubmit_AnonymousAllowed(t *testing.T) {
 	}
 	if sub.UserName.Valid {
 		t.Fatalf("expected anonymous submission, got %+v", sub.UserName)
+	}
+}
+
+func TestPostRejudge_AllowsSubmissionOwner(t *testing.T) {
+	db := setupTestDB(t)
+	problem := database.Problem{
+		Name:             "aplusb-rejudge",
+		Title:            "A + B",
+		SourceUrl:        "https://example.com/aplusb",
+		Timelimit:        2000,
+		TestCasesVersion: "v1",
+		Version:          "1",
+		OverallVersion:   "1",
+	}
+	if err := database.SaveProblem(db, problem); err != nil {
+		t.Fatalf("save problem: %v", err)
+	}
+	if err := database.RegisterUser(db, "alice", "uid-rejudge"); err != nil {
+		t.Fatalf("register user: %v", err)
+	}
+	id, err := database.SaveSubmission(db, database.Submission{
+		ProblemName:      problem.Name,
+		Lang:             "cpp",
+		Status:           "AC",
+		Source:           "#include <bits/stdc++.h>\nint main(){return 0;}",
+		TestCasesVersion: "v1",
+		MaxTime:          1,
+		MaxMemory:        1,
+		UserName:         sql.NullString{String: "alice", Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("save submission: %v", err)
+	}
+
+	s := &server{db: db, authClient: fakeAuthClient{uid: "uid-rejudge"}}
+	req := httptest.NewRequest(http.MethodPost, "/submissions/1/rejudge", nil)
+	req.Header.Set("Authorization", "Bearer token")
+	ctx := withHTTPRequest(context.Background(), req)
+	respObj, err := s.PostRejudge(ctx, restapi.PostRejudgeRequestObject{Id: id})
+	if err != nil {
+		t.Fatalf("PostRejudge returned error: %v", err)
+	}
+	if _, ok := respObj.(restapi.PostRejudge200JSONResponse); !ok {
+		t.Fatalf("unexpected response type %T", respObj)
+	}
+}
+
+func TestPostRejudge_RejectsAnonymous(t *testing.T) {
+	db := setupTestDB(t)
+	s := &server{db: db}
+	req := httptest.NewRequest(http.MethodPost, "/submissions/1/rejudge", nil)
+	ctx := withHTTPRequest(context.Background(), req)
+	_, err := s.PostRejudge(ctx, restapi.PostRejudgeRequestObject{Id: 1})
+	if err == nil {
+		t.Fatalf("expected unauthorized error")
+	}
+	if httpErr, ok := getHTTPError(err); !ok || httpErr.Status != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %v", err)
 	}
 }

--- a/restapi/internal/api/api.gen.go
+++ b/restapi/internal/api/api.gen.go
@@ -46,14 +46,6 @@ type ChangeCurrentUserInfoRequest struct {
 // ChangeCurrentUserInfoResponse defines model for ChangeCurrentUserInfoResponse.
 type ChangeCurrentUserInfoResponse = map[string]interface{}
 
-// ChangeUserInfoRequest defines model for ChangeUserInfoRequest.
-type ChangeUserInfoRequest struct {
-	User User `json:"user"`
-}
-
-// ChangeUserInfoResponse defines model for ChangeUserInfoResponse.
-type ChangeUserInfoResponse = map[string]interface{}
-
 // CreateHackRequest defines model for CreateHackRequest.
 type CreateHackRequest struct {
 	Submission  int32   `json:"submission"`
@@ -352,9 +344,6 @@ type PostHackJSONRequestBody = CreateHackRequest
 // PostSubmitJSONRequestBody defines body for PostSubmit for application/json ContentType.
 type PostSubmitJSONRequestBody = SubmitRequest
 
-// PatchUserInfoJSONRequestBody defines body for PatchUserInfo for application/json ContentType.
-type PatchUserInfoJSONRequestBody = ChangeUserInfoRequest
-
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
 	// Get current user info
@@ -408,9 +397,6 @@ type ServerInterface interface {
 	// Get user info
 	// (GET /users/{name})
 	GetUserInfo(w http.ResponseWriter, r *http.Request, name UserNamePath)
-	// Change user info
-	// (PATCH /users/{name})
-	PatchUserInfo(w http.ResponseWriter, r *http.Request, name UserNamePath)
 	// Get user solved statistics
 	// (GET /users/{name}/statistics)
 	GetUserStatistics(w http.ResponseWriter, r *http.Request, name UserNamePath)
@@ -519,12 +505,6 @@ func (_ Unimplemented) PostSubmit(w http.ResponseWriter, r *http.Request) {
 // Get user info
 // (GET /users/{name})
 func (_ Unimplemented) GetUserInfo(w http.ResponseWriter, r *http.Request, name UserNamePath) {
-	w.WriteHeader(http.StatusNotImplemented)
-}
-
-// Change user info
-// (PATCH /users/{name})
-func (_ Unimplemented) PatchUserInfo(w http.ResponseWriter, r *http.Request, name UserNamePath) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -1009,37 +989,6 @@ func (siw *ServerInterfaceWrapper) GetUserInfo(w http.ResponseWriter, r *http.Re
 	handler.ServeHTTP(w, r)
 }
 
-// PatchUserInfo operation middleware
-func (siw *ServerInterfaceWrapper) PatchUserInfo(w http.ResponseWriter, r *http.Request) {
-
-	var err error
-
-	// ------------- Path parameter "name" -------------
-	var name UserNamePath
-
-	err = runtime.BindStyledParameterWithOptions("simple", "name", chi.URLParam(r, "name"), &name, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
-	if err != nil {
-		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "name", Err: err})
-		return
-	}
-
-	ctx := r.Context()
-
-	ctx = context.WithValue(ctx, FirebaseAuthScopes, []string{})
-
-	r = r.WithContext(ctx)
-
-	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.PatchUserInfo(w, r, name)
-	}))
-
-	for _, middleware := range siw.HandlerMiddlewares {
-		handler = middleware(handler)
-	}
-
-	handler.ServeHTTP(w, r)
-}
-
 // GetUserStatistics operation middleware
 func (siw *ServerInterfaceWrapper) GetUserStatistics(w http.ResponseWriter, r *http.Request) {
 
@@ -1228,9 +1177,6 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/users/{name}", wrapper.GetUserInfo)
-	})
-	r.Group(func(r chi.Router) {
-		r.Patch(options.BaseURL+"/users/{name}", wrapper.PatchUserInfo)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/users/{name}/statistics", wrapper.GetUserStatistics)
@@ -1523,24 +1469,6 @@ func (response GetUserInfo200JSONResponse) VisitGetUserInfoResponse(w http.Respo
 	return json.NewEncoder(w).Encode(response)
 }
 
-type PatchUserInfoRequestObject struct {
-	Name UserNamePath `json:"name"`
-	Body *PatchUserInfoJSONRequestBody
-}
-
-type PatchUserInfoResponseObject interface {
-	VisitPatchUserInfoResponse(w http.ResponseWriter) error
-}
-
-type PatchUserInfo200JSONResponse ChangeUserInfoResponse
-
-func (response PatchUserInfo200JSONResponse) VisitPatchUserInfoResponse(w http.ResponseWriter) error {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
-
-	return json.NewEncoder(w).Encode(response)
-}
-
 type GetUserStatisticsRequestObject struct {
 	Name UserNamePath `json:"name"`
 }
@@ -1611,9 +1539,6 @@ type StrictServerInterface interface {
 	// Get user info
 	// (GET /users/{name})
 	GetUserInfo(ctx context.Context, request GetUserInfoRequestObject) (GetUserInfoResponseObject, error)
-	// Change user info
-	// (PATCH /users/{name})
-	PatchUserInfo(ctx context.Context, request PatchUserInfoRequestObject) (PatchUserInfoResponseObject, error)
 	// Get user solved statistics
 	// (GET /users/{name}/statistics)
 	GetUserStatistics(ctx context.Context, request GetUserStatisticsRequestObject) (GetUserStatisticsResponseObject, error)
@@ -2100,39 +2025,6 @@ func (sh *strictHandler) GetUserInfo(w http.ResponseWriter, r *http.Request, nam
 	}
 }
 
-// PatchUserInfo operation middleware
-func (sh *strictHandler) PatchUserInfo(w http.ResponseWriter, r *http.Request, name UserNamePath) {
-	var request PatchUserInfoRequestObject
-
-	request.Name = name
-
-	var body PatchUserInfoJSONRequestBody
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
-		return
-	}
-	request.Body = &body
-
-	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
-		return sh.ssi.PatchUserInfo(ctx, request.(PatchUserInfoRequestObject))
-	}
-	for _, middleware := range sh.middlewares {
-		handler = middleware(handler, "PatchUserInfo")
-	}
-
-	response, err := handler(r.Context(), w, r, request)
-
-	if err != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, err)
-	} else if validResponse, ok := response.(PatchUserInfoResponseObject); ok {
-		if err := validResponse.VisitPatchUserInfoResponse(w); err != nil {
-			sh.options.ResponseErrorHandlerFunc(w, r, err)
-		}
-	} else if response != nil {
-		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
-	}
-}
-
 // GetUserStatistics operation middleware
 func (sh *strictHandler) GetUserStatistics(w http.ResponseWriter, r *http.Request, name UserNamePath) {
 	var request GetUserStatisticsRequestObject
@@ -2162,49 +2054,48 @@ func (sh *strictHandler) GetUserStatistics(w http.ResponseWriter, r *http.Reques
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/8xbe3PbuBH/Khj0ZprM0ZacpGmr/3yetE3rXFw7ns7U43JgciUhIgEGAH1RM/ruNwD4",
-	"AJ8iacnjvxJLWGD3tw/sLlY/cMDjhDNgSuLFD5wQQWJQIMxf/yDB5mOo/xeCDARNFOUML8zniIbAFF1S",
-	"EKfYw1R/nhC1xh5mJAa8wDTEHhbwLaUCQrxQIgUPy2ANMdFbLrmIidLrmHr7Bns4pozGaYwXcw+rbQL2",
-	"K1iBwLudZw69pDFVTX4+ke+aErE0fgCB+BKtSbCRSHEkQKWCoVdnJ2fz+fx1weq3FMS25DUyG7vshbAk",
-	"aaTw4mw+91qYtUear+cO72edvN9saNJk/dcmy3JDE/QASy4ABTyKIFCUrZAAmUZKdkmgqdoFaGW/H+sr",
-	"wR8iiH81W9dZzr7cbwDmnz4T+EnAEi/wH2alEc7st3LmsqBZuiZsQ9lqsAUIux4JCLgIX5AtZILsM4cW",
-	"/l+AYdykDzGVknLWFhfKb589OpRHD7YQWZC8IOso5dhnIDX2X4Bx3EoQ2l+vtKIbnOtvjxwz9BHMBoxd",
-	"TmMusos1YSu4SIUApvSqj2zJr+FbCtKYCglDqtkk0ZXgCQhFQeLFkkQSPJw4H/3AqQQxhA+DSCnGnSW8",
-	"L4DjD18hUHjndTEnE84k7OWuY7uXKeQBpBNAFOj71JGsynzpGKMDiYcVSOUHRIIfJEmF/mGrtGVmJFIJ",
-	"ylZVCvVdDaCoIeZw24rbRLN4gj4bPJg0sHZ4df+vabgCn6cqSdUg0PgjiEcKv+1jSh/9OV+rfVqFIMRI",
-	"vTyTJguZ7jswvKRSdWMY8JSpVottWqnJFfVaqiCWY0HM9iNCkG1DCru1l7HTJcpnR39VMTS9r6hNHAtR",
-	"QqLgxHzagjsNJzhqDDEX2zrh+3eteElFVGrYaxxe+p8/iY+GqMuIE1VyYfMNvVI7oc+ylLrflExyVOWs",
-	"EMJzIO5ST7eVTZCxyVvbsZeErUZGJctLQyMdEHn4EUQe1QfAl2USOVEXz3WnHMF/RNhquBcagPZ5n92y",
-	"lVf6IIjY3oqomVp9TizH6Pb6Ei25QGoNSJvbHyWKLB1KBF/SCE7RrQREGII4UVtkAdT54wYgQVShlElQ",
-	"pzZvvQS20qncm/m8xW0/cUYV139NxE8RufG/pZDCPuy+ELn5t16oryEDIlck8p0UeGDgtHQammEUNfW4",
-	"5G1MeK5MbVrMqtqRQOUeMbhe1mFJRQMCTeYkdnUPwxdEwYoLCnKiroNig8EOUz16u9d3nCP2S7IdyX9i",
-	"qUdzX+ijwvlg/dhlXnl8j2RPyA916kKiyO+OsB6WPBUB+GlbAPrwXenKK0ICliCABVCEoYxzpG8viIGZ",
-	"2NKaeunMS/ayoO88P8rr+8aN23KJlbdvF+AjrpVcGQ4SFZ7KrdoE8hoo9+jyCbfSVEvd619DbHBoxxAF",
-	"nEkqTYuCL1HEfwOh4UIRKAVCeiikK6qkh7hAKQtByIALkLWL6SzrqBR/ezghegN96v/uyMn/5yd/9e9/",
-	"/qnN5rJG3NSA1pmu9+eL2g+04MFwBenK7KYk26cn54S+NP4aVlQqENM6BEOuJKcd03Lr9PM0tT9wDaYW",
-	"nb7BDY8eIbwpCoZah9N8i2wqbmIcySOcNk1gWu93+PL8y4ebL/75Bfbw+YUjaml9ZaPvgkjNr+m6NYpC",
-	"ItuDVrCGYANC19yDatuDlUsjCvCBlVHjGpfgVjtZ1ZgJ0GY1TlO6t0sREOYLax+ObA+cR0CYAVXX/lnH",
-	"dLB3tiqy5cbXpDQCH4Tg4qBNkpKDSqvE3FL7b7XilILEqyDVj/jhehq1ZH4k9oP7G9V0vTs8OluL0HbP",
-	"it44PjEVZj00CHud6eUmNDhHucHBEv9cK+DbIkN3l6WjjG+iSqUfEZXF96bFR1nV/rR4kUVAv7Nyzxd0",
-	"J2HDOjTj+krHa81UBK6Ll6HqYj8+nKlp13KuTydHev+uniJ1qWdkSVMGmLoj6M9RwENAiiMTRdCrmHxH",
-	"Z+gT/eV1I4d795c//fn9XiZVBP6G8WCTXXl1Y27PVt2oZsDpQ3xSIni0jlq16TGyCAAWUrbyFZGbob0R",
-	"kTI2lsa2QIZT1JVUYbPOQnX7Nohus3eNMeqSfgiPEOnPOmKi7ZjllW5vT69syjmNy+k5cfVwr8psFwDP",
-	"9S406J3P1CpFCm3LkInMSbONH5Okm3BPeuDm8s2XrXpmUJ7XKVmleHuGavEQJtWd4xSUzcd6Rr+ltofc",
-	"U7XXa/X1NlkDq9XstXD/trdiPz/5ry3aT9qrdn3tQJAKqrY3WnyL7pIKeCASzlM7ePAARID4Ww71P//z",
-	"JZ9xMK5uvi33XiuV2IkBmgXaLE3Je+7owhZb6PrDzRd0fvURvTJaI9Frp+ezwPPTs9O5SdwTYCSheIHf",
-	"ns5P32Ij49qwOiOpWs8C+6rr5/63AmMc2mKIyoZr8N9B1V5/zWCE9SWz2Zv53BoXU2DNiyRJRAOzx+yr",
-	"tE2tYbMTXQ/NBpjac8O/rCLSOCY6R9ScokykzGSyNn1CVLBuSnalP26TzaQ8v/Bwezix+iY/dlWPUSKF",
-	"3TEh7h306AE6s3i8uKvb+t397t7VhD2iTRk7L7M9kfVYTJrAZYvhXXFd02WrjqOWevPpmTXR6DMdBPx8",
-	"VwO7Rbz67NHl5o1HlmM6eveLzlBXz1v6jnBG2GIqoUvOfAjCBMRy0PiuneFyyayYn915g9baGUC9uG3o",
-	"zajHnSlrXDLtdEUNN5rS9ARqc3b13kHWOHh1QkOUdRo8REMP6YrRQ6bKfd3yeKJt8GjG0hhbGWIjmsCO",
-	"M5s7oDPG6M2PFfYbY2LPHGEqUxgHiS62SDW4IgVSIdMoLR1v9oOGu33el920473vY4iPbmiT8g6DR3nF",
-	"FTMZXSjkMx/HDLGNuZKhwmjuU7ICFFFpC5RZXExZ9ElVzmIcU66WiY+hkpVioJAoYmVznyr33I3PcSVO",
-	"UlkhQ0Wi2Q8d+XcDBJvkkZVO3P3xkZnkmXmaUDpn9puGPlSyR9nRiLi/qhiQJFR+TXJUBOuvzEPRy7Ey",
-	"wNXeRrrAqz7LjMaw9tuDATDWf3XRlf84zdgpP/45dDqm7wwI2yidbvLA3HFoZ6Z9uxDCNLntyEf3MpO9",
-	"MxwgHR34yGbojptxdjwtDnUb91cx5SXqfLo3Taq+Jj/BiY6dMnU8e49HyonQdaBmznt5X7PALnq5WNXH",
-	"Qg5U79u3LeJg6cCo+kGz+fyR6p/qG+Iz1z6157RDVj8ESR6lqgDajOIOSLacLuM4E638pu2oJjq58zq4",
-	"43pIEI7VqX0RLdqj9mZrPVnXgmfV4cA+Y75xh/xeskl3PgaOMm9Zzt3lU5AWffGYS22ea/EM7+53vwcA",
-	"AP///FvTE9ZAAAA=",
+	"H4sIAAAAAAAC/8xbe2/buhX/KgR3gbW4Suy0Xbf5v9yg27qlt1nSYMCCTGCkY5u1RKoklVuv8He/IKkH",
+	"9bSk2EH+amPzcc6P532Of+CAxwlnwJTEix84IYLEoECYv/5Bgs3HUP8vBBkImijKGV6YzxENgSm6pCBO",
+	"sYep/jwhao09zEgMeIFpiD0s4FtKBYR4oUQKHpbBGmKij1xyEROl1zH19g32cEwZjdMYL+YeVtsE7Few",
+	"AoF3O89cekljqpr0fCLf9U7E0vgBBOJLtCbBRiLFkQCVCoZenZ2czefz1wWp31IQ25LWyBzskhfCkqSR",
+	"wouz+dxrIdZeab6eO7SfddJ+s6FJk/RfmyTLDU3QAyy5ABTwKIJAUbZCAmQaKdnFgd7VzkAr+f1YXwn+",
+	"EEH8qzm6TnL25X4BMP/0icBPApZ4gf8wK4VwZr+VM5cETdI1YRvKVoMlQNj1SEDARfiCZCFjZJ84tND/",
+	"AgTjJn2IqZSUsza7UH777NahvHqwhMhiywuSjpKPfQJSI/8FCMetBKH19Uo/dINy/e2RbYa+glmDscv3",
+	"GEd2sSZsBRepEMCUXvWRLfk1fEtBGlEhYUg1mSS6EjwBoShIvFiSSIKHE+ejHziVIIbQYRAp2bizG+8L",
+	"4PjDVwgU3nldxMmEMwl7qWseJ4Ao0B7HYbDKQyk6o1XNwwqk8gMiwQ+SpLL/Yav022VbpBKUrao71Hc1",
+	"YEcNOIfaVvgmAveEZ23QYAKl2uXV87+m4Qp8nqokVYNA448gHin8to8offXnfK2WehWCECPf5ZlesuDp",
+	"vgPDSypVN4YBT5lqldimlJpoSq+lCmI5FsTsPCIE2Ta4sEd7GTldrHx23q/Kht7vK2pDq4KVkCg4MZ+2",
+	"4E7DCYoaQ8zFtr7x/btWvKQiKjXkNS4v9c+fREeD1WXEiSqpsB5Zr9RK6LMs6OwXJRM+VCkrmPAciLue",
+	"p1vKJvDYpK3t2kvCViOtkqWl8SIdEHn4EURu1QfAl/nafFMXzXWlHEF/RNhquBYagPZpnz2ylVb6IIjY",
+	"3oqoGXx8TizF6Pb6Ei25QGoNSIvbHyWK7D6UCL6kEZyiWwmIMARxorbIAqgjrA1AgqhCKZOgTm1kdwls",
+	"pYOdN/N5i9p+4owqrv+aiJ8icuN/SyGFfdh9IXLzb71QuyEDIlck8p0gcaDhtPs0NMN21J7H3d5GhOfy",
+	"1PaKWd43EqhcIwZnlNosqWiAocmUxK7uIfiCKFhxQUFOfOugOGCwwlSv3u7VHeeK/ZxsR9Kf2N2jqS/e",
+	"o0L54Pexy7zy+h7OnhAf6tCFRJHfbWE9LHkqAvDTNgP04bvSuUmEBCxBAAugMEMZ5Uh7L4iBGdvSGnrp",
+	"yEv2kqB9nh/lGXDD47Y4sdL7dgE+wq3kj+EgUaGpPKqNIa+Bcs9bPsErTZXUvfo1RAaH1tRQwJmk0iTx",
+	"fIki/hsIDReKQCkQ0kMhXVElPcQFSlkIQgZcgKw5prOs5lD87emEW8siXuD/3ZGT/89P/urf//xTm8xl",
+	"paqpBq0zXO+PF7UeaMaD4Q+kM7Obctu+d3Ju6Avjr2FFpQIxrVAwxCU5BYsWr9NP09T6wDWYXHT6ATc8",
+	"eoTwpkgYajVA8y2yobixcSS3cFo0gel3v8OX518+3Hzxzy+wh88vHFZL6StLYRdEanpNXaqRFBLZbrSC",
+	"NQQbEDrnHpTbHixdGpGAD8yMGm5cgpvtZFljxkCb1Dhl294qRUCYL6x8OLw9cB4BYQZUnftnNcXB2tn6",
+	"kC0eX2+lEfggBBcHLZKUFFRKJcZL7fdqxS3FFq+CVD/ih6tp1IL5kdgPrm9Uw/Vu8+gcLUJbPSuqx/jE",
+	"ZJh10yCsO9PLjWlwrnKNg938cy2Bb7MM3VWWjjS+iSqVfkRUZt+bEh9lWfvT7EVmAf3OzD1f0B2EDavQ",
+	"jKsrHa80U2G4zl6Gqov9eHOmprnl/D2dGOn9u3qI1PU8I1Oa0sDUFUF/jgIeAlIcGSuCXsXkOzpDn+gv",
+	"rxsx3Lu//OnP7/cSqSLwN4wHm8zl1YW5PVp1rZoBpw/xSYHg0Spq1aLHyCQAWEjZyldEbobWRkTK2Ng9",
+	"tgQyfEf9kSpk1kmoHt8G0W3W1xjzXNIP4REi/VmHTbQVszzT7a3plUU5p3A5PSauXu5Vie0C4Ln6QoPa",
+	"fSZXKUJom4ZMJE6aY/yYJN0b94QHbizf7GzVI4Pyvk7OKsnbM2SLhxCp7hin2NlsZzP6LbU15J6svZ6r",
+	"r7fJGlgtZ6+Z+7e9Gfv5yX9t0n7SnrVrtwNBKqja3mj2LbpLKuCBSDhPbWv+AYgA8bcc6n/+50s+BWBU",
+	"3Xxbnr1WKrE9dZoZ2ixMyWvu6MImW+j6w80XdH71Eb0yr0ai107NZ4Hnp2encxO4J8BIQvECvz2dn77F",
+	"hse1IXVGUrWeBbar6+f6twIjHFpiiMrGT/DfQdW6v2Z0wOqSOezNfG6Fiymw4kWSJKKBOWP2Vdqi1rDp",
+	"gq5GswGm1m74l32INI6JjhE1pShjKROZrEyfEBWsm5xd6Y/beDMhzy883B6Orb7ZiF1VY5RIYXdMiHtH",
+	"IXqAziQeL+7qsn53v7t3X8Je0fYYOy+TPZHVWEyYwGWL4F1xndNlq47zLPXi0zO/RKPOdBDw81MN7Bbx",
+	"atujS80bTZZjKnp3R2eoquclfYc5w2wxldDFZz4EYQxiOYp7105wuWRWTJjuvEFr7ZScXtw2Fmaex526",
+	"ajiZ9n1FDjd6p6kJ1CbR6rWDrHDw6oSGKKs0eIiGHtIZo4dMlvu6pXmiZfBowtIYWxkiI3qDHfg1PqDT",
+	"xujDj2X2G2Niz2xhKlMYB7EuNkk1uCIFUiFTKC0Vb/aDhrt92pd52vHa9zHERxe0SXGHwaN0ccVMRhcK",
+	"+czHMU1sY65kKDOa+pSsAEVU2gRlFhdTFn1clbMYx+SrZeJjKGclGygkilje3FblHt/4HC5x0pMVPFQ4",
+	"mv3Qln83gLFJGlmpxN0fH5lJmpmHCaVyZlP/fahkTdnRiLi/OxgQJFR+b3FUBOtd5qHo5VgZ4Gq9kS7w",
+	"qm2Z0RjWpvMHwFj/XUJX/OMUY6f8PObQ4Zj2GRC27XSqyQNjx6GVmfbjQgjT5LYjHt1LTNZnOEA4OrDJ",
+	"ZvYdN+LsaC0OVRv3dyOlE3U+3RsmVbvJT1CiY4dMHW3v8Ug5FroO1Mzpl/cVC+yil4tVfSzkQPm+7W0R",
+	"B0sHRtUPmo3nj5T/VHuIz5z71Npph8x+CJI8SlUBtBnFHRBsOVXGcSJa+dXXUUV0cuW1VuRzIZlVp836",
+	"0Llxp8ZeMkad3aVReMlykCsfq7MSKR5zrk3/D8/w7n73ewAAAP//jKndBUk+AAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/restapi/internal/api/api.gen.go
+++ b/restapi/internal/api/api.gen.go
@@ -46,6 +46,14 @@ type ChangeCurrentUserInfoRequest struct {
 // ChangeCurrentUserInfoResponse defines model for ChangeCurrentUserInfoResponse.
 type ChangeCurrentUserInfoResponse = map[string]interface{}
 
+// ChangeUserInfoRequest defines model for ChangeUserInfoRequest.
+type ChangeUserInfoRequest struct {
+	User User `json:"user"`
+}
+
+// ChangeUserInfoResponse defines model for ChangeUserInfoResponse.
+type ChangeUserInfoResponse = map[string]interface{}
+
 // CreateHackRequest defines model for CreateHackRequest.
 type CreateHackRequest struct {
 	Submission  int32   `json:"submission"`
@@ -104,6 +112,13 @@ type LangListResponse struct {
 // LibraryUrl Optional URL for the user's library profile. Use an empty string to keep it unset.
 type LibraryUrl = string
 
+// MonitoringResponse defines model for MonitoringResponse.
+type MonitoringResponse struct {
+	TaskQueue        TaskQueueInfo `json:"task_queue"`
+	TotalSubmissions int32         `json:"total_submissions"`
+	TotalUsers       int32         `json:"total_users"`
+}
+
 // Problem defines model for Problem.
 type Problem struct {
 	// Name Problem identifier consisting of lowercase letters, digits, or underscores.
@@ -156,6 +171,9 @@ type RegisterRequest struct {
 
 // RegisterResponse defines model for RegisterResponse.
 type RegisterResponse = map[string]interface{}
+
+// RejudgeResponse defines model for RejudgeResponse.
+type RejudgeResponse = map[string]interface{}
 
 // SolvedStatus Solved status for a problem.
 type SolvedStatus string
@@ -217,6 +235,13 @@ type SubmitRequest struct {
 // SubmitResponse defines model for SubmitResponse.
 type SubmitResponse struct {
 	Id int32 `json:"id"`
+}
+
+// TaskQueueInfo defines model for TaskQueueInfo.
+type TaskQueueInfo struct {
+	PendingTasks int32 `json:"pending_tasks"`
+	RunningTasks int32 `json:"running_tasks"`
+	TotalTasks   int32 `json:"total_tasks"`
 }
 
 // User defines model for User.
@@ -327,6 +352,9 @@ type PostHackJSONRequestBody = CreateHackRequest
 // PostSubmitJSONRequestBody defines body for PostSubmit for application/json ContentType.
 type PostSubmitJSONRequestBody = SubmitRequest
 
+// PatchUserInfoJSONRequestBody defines body for PatchUserInfo for application/json ContentType.
+type PatchUserInfoJSONRequestBody = ChangeUserInfoRequest
+
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
 	// Get current user info
@@ -353,6 +381,9 @@ type ServerInterface interface {
 	// Get language list
 	// (GET /langs)
 	GetLangList(w http.ResponseWriter, r *http.Request)
+	// Get monitoring data
+	// (GET /monitoring)
+	GetMonitoring(w http.ResponseWriter, r *http.Request)
 	// Get problems
 	// (GET /problems)
 	GetProblems(w http.ResponseWriter, r *http.Request)
@@ -368,12 +399,18 @@ type ServerInterface interface {
 	// Get submission info
 	// (GET /submissions/{id})
 	GetSubmissionInfo(w http.ResponseWriter, r *http.Request, id SubmissionId)
+	// Rejudge a submission
+	// (POST /submissions/{id}/rejudge)
+	PostRejudge(w http.ResponseWriter, r *http.Request, id SubmissionId)
 	// Submit a solution
 	// (POST /submit)
 	PostSubmit(w http.ResponseWriter, r *http.Request)
 	// Get user info
 	// (GET /users/{name})
 	GetUserInfo(w http.ResponseWriter, r *http.Request, name UserNamePath)
+	// Change user info
+	// (PATCH /users/{name})
+	PatchUserInfo(w http.ResponseWriter, r *http.Request, name UserNamePath)
 	// Get user solved statistics
 	// (GET /users/{name}/statistics)
 	GetUserStatistics(w http.ResponseWriter, r *http.Request, name UserNamePath)
@@ -431,6 +468,12 @@ func (_ Unimplemented) GetLangList(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
+// Get monitoring data
+// (GET /monitoring)
+func (_ Unimplemented) GetMonitoring(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
 // Get problems
 // (GET /problems)
 func (_ Unimplemented) GetProblems(w http.ResponseWriter, r *http.Request) {
@@ -461,6 +504,12 @@ func (_ Unimplemented) GetSubmissionInfo(w http.ResponseWriter, r *http.Request,
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
+// Rejudge a submission
+// (POST /submissions/{id}/rejudge)
+func (_ Unimplemented) PostRejudge(w http.ResponseWriter, r *http.Request, id SubmissionId) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
 // Submit a solution
 // (POST /submit)
 func (_ Unimplemented) PostSubmit(w http.ResponseWriter, r *http.Request) {
@@ -470,6 +519,12 @@ func (_ Unimplemented) PostSubmit(w http.ResponseWriter, r *http.Request) {
 // Get user info
 // (GET /users/{name})
 func (_ Unimplemented) GetUserInfo(w http.ResponseWriter, r *http.Request, name UserNamePath) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Change user info
+// (PATCH /users/{name})
+func (_ Unimplemented) PatchUserInfo(w http.ResponseWriter, r *http.Request, name UserNamePath) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -674,6 +729,20 @@ func (siw *ServerInterfaceWrapper) GetLangList(w http.ResponseWriter, r *http.Re
 	handler.ServeHTTP(w, r)
 }
 
+// GetMonitoring operation middleware
+func (siw *ServerInterfaceWrapper) GetMonitoring(w http.ResponseWriter, r *http.Request) {
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetMonitoring(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // GetProblems operation middleware
 func (siw *ServerInterfaceWrapper) GetProblems(w http.ResponseWriter, r *http.Request) {
 
@@ -864,6 +933,37 @@ func (siw *ServerInterfaceWrapper) GetSubmissionInfo(w http.ResponseWriter, r *h
 	handler.ServeHTTP(w, r)
 }
 
+// PostRejudge operation middleware
+func (siw *ServerInterfaceWrapper) PostRejudge(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "id" -------------
+	var id SubmissionId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, FirebaseAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PostRejudge(w, r, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 // PostSubmit operation middleware
 func (siw *ServerInterfaceWrapper) PostSubmit(w http.ResponseWriter, r *http.Request) {
 
@@ -900,6 +1000,37 @@ func (siw *ServerInterfaceWrapper) GetUserInfo(w http.ResponseWriter, r *http.Re
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetUserInfo(w, r, name)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// PatchUserInfo operation middleware
+func (siw *ServerInterfaceWrapper) PatchUserInfo(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "name" -------------
+	var name UserNamePath
+
+	err = runtime.BindStyledParameterWithOptions("simple", "name", chi.URLParam(r, "name"), &name, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "name", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, FirebaseAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.PatchUserInfo(w, r, name)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -1072,6 +1203,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Get(options.BaseURL+"/langs", wrapper.GetLangList)
 	})
 	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/monitoring", wrapper.GetMonitoring)
+	})
+	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/problems", wrapper.GetProblems)
 	})
 	r.Group(func(r chi.Router) {
@@ -1087,10 +1221,16 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Get(options.BaseURL+"/submissions/{id}", wrapper.GetSubmissionInfo)
 	})
 	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/submissions/{id}/rejudge", wrapper.PostRejudge)
+	})
+	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/submit", wrapper.PostSubmit)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/users/{name}", wrapper.GetUserInfo)
+	})
+	r.Group(func(r chi.Router) {
+		r.Patch(options.BaseURL+"/users/{name}", wrapper.PatchUserInfo)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/users/{name}/statistics", wrapper.GetUserStatistics)
@@ -1232,6 +1372,22 @@ func (response GetLangList200JSONResponse) VisitGetLangListResponse(w http.Respo
 	return json.NewEncoder(w).Encode(response)
 }
 
+type GetMonitoringRequestObject struct {
+}
+
+type GetMonitoringResponseObject interface {
+	VisitGetMonitoringResponse(w http.ResponseWriter) error
+}
+
+type GetMonitoring200JSONResponse MonitoringResponse
+
+func (response GetMonitoring200JSONResponse) VisitGetMonitoringResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type GetProblemsRequestObject struct {
 }
 
@@ -1316,6 +1472,23 @@ func (response GetSubmissionInfo200JSONResponse) VisitGetSubmissionInfoResponse(
 	return json.NewEncoder(w).Encode(response)
 }
 
+type PostRejudgeRequestObject struct {
+	Id SubmissionId `json:"id"`
+}
+
+type PostRejudgeResponseObject interface {
+	VisitPostRejudgeResponse(w http.ResponseWriter) error
+}
+
+type PostRejudge200JSONResponse RejudgeResponse
+
+func (response PostRejudge200JSONResponse) VisitPostRejudgeResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type PostSubmitRequestObject struct {
 	Body *PostSubmitJSONRequestBody
 }
@@ -1344,6 +1517,24 @@ type GetUserInfoResponseObject interface {
 type GetUserInfo200JSONResponse UserInfoResponse
 
 func (response GetUserInfo200JSONResponse) VisitGetUserInfoResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type PatchUserInfoRequestObject struct {
+	Name UserNamePath `json:"name"`
+	Body *PatchUserInfoJSONRequestBody
+}
+
+type PatchUserInfoResponseObject interface {
+	VisitPatchUserInfoResponse(w http.ResponseWriter) error
+}
+
+type PatchUserInfo200JSONResponse ChangeUserInfoResponse
+
+func (response PatchUserInfo200JSONResponse) VisitPatchUserInfoResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)
 
@@ -1393,6 +1584,9 @@ type StrictServerInterface interface {
 	// Get language list
 	// (GET /langs)
 	GetLangList(ctx context.Context, request GetLangListRequestObject) (GetLangListResponseObject, error)
+	// Get monitoring data
+	// (GET /monitoring)
+	GetMonitoring(ctx context.Context, request GetMonitoringRequestObject) (GetMonitoringResponseObject, error)
 	// Get problems
 	// (GET /problems)
 	GetProblems(ctx context.Context, request GetProblemsRequestObject) (GetProblemsResponseObject, error)
@@ -1408,12 +1602,18 @@ type StrictServerInterface interface {
 	// Get submission info
 	// (GET /submissions/{id})
 	GetSubmissionInfo(ctx context.Context, request GetSubmissionInfoRequestObject) (GetSubmissionInfoResponseObject, error)
+	// Rejudge a submission
+	// (POST /submissions/{id}/rejudge)
+	PostRejudge(ctx context.Context, request PostRejudgeRequestObject) (PostRejudgeResponseObject, error)
 	// Submit a solution
 	// (POST /submit)
 	PostSubmit(ctx context.Context, request PostSubmitRequestObject) (PostSubmitResponseObject, error)
 	// Get user info
 	// (GET /users/{name})
 	GetUserInfo(ctx context.Context, request GetUserInfoRequestObject) (GetUserInfoResponseObject, error)
+	// Change user info
+	// (PATCH /users/{name})
+	PatchUserInfo(ctx context.Context, request PatchUserInfoRequestObject) (PatchUserInfoResponseObject, error)
 	// Get user solved statistics
 	// (GET /users/{name}/statistics)
 	GetUserStatistics(ctx context.Context, request GetUserStatisticsRequestObject) (GetUserStatisticsResponseObject, error)
@@ -1665,6 +1865,30 @@ func (sh *strictHandler) GetLangList(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// GetMonitoring operation middleware
+func (sh *strictHandler) GetMonitoring(w http.ResponseWriter, r *http.Request) {
+	var request GetMonitoringRequestObject
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetMonitoring(ctx, request.(GetMonitoringRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetMonitoring")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetMonitoringResponseObject); ok {
+		if err := validResponse.VisitGetMonitoringResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
 // GetProblems operation middleware
 func (sh *strictHandler) GetProblems(w http.ResponseWriter, r *http.Request) {
 	var request GetProblemsRequestObject
@@ -1793,6 +2017,32 @@ func (sh *strictHandler) GetSubmissionInfo(w http.ResponseWriter, r *http.Reques
 	}
 }
 
+// PostRejudge operation middleware
+func (sh *strictHandler) PostRejudge(w http.ResponseWriter, r *http.Request, id SubmissionId) {
+	var request PostRejudgeRequestObject
+
+	request.Id = id
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.PostRejudge(ctx, request.(PostRejudgeRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "PostRejudge")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(PostRejudgeResponseObject); ok {
+		if err := validResponse.VisitPostRejudgeResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
 // PostSubmit operation middleware
 func (sh *strictHandler) PostSubmit(w http.ResponseWriter, r *http.Request) {
 	var request PostSubmitRequestObject
@@ -1850,6 +2100,39 @@ func (sh *strictHandler) GetUserInfo(w http.ResponseWriter, r *http.Request, nam
 	}
 }
 
+// PatchUserInfo operation middleware
+func (sh *strictHandler) PatchUserInfo(w http.ResponseWriter, r *http.Request, name UserNamePath) {
+	var request PatchUserInfoRequestObject
+
+	request.Name = name
+
+	var body PatchUserInfoJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.PatchUserInfo(ctx, request.(PatchUserInfoRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "PatchUserInfo")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(PatchUserInfoResponseObject); ok {
+		if err := validResponse.VisitPatchUserInfoResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
 // GetUserStatistics operation middleware
 func (sh *strictHandler) GetUserStatistics(w http.ResponseWriter, r *http.Request, name UserNamePath) {
 	var request GetUserStatisticsRequestObject
@@ -1879,46 +2162,49 @@ func (sh *strictHandler) GetUserStatistics(w http.ResponseWriter, r *http.Reques
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/8xbe2/cuBH/KgR7QBOc7F0nadrufz4jbdP6LoYdo0ANV+BKs7uMJVIhKV+2xn73gqQe",
-	"1HMledfwX3fW8jHzm/cM84QDHiecAVMSL55wQgSJQYEwf/2DBA+fQ/1/IchA0ERRzvDCfEc0BKboioI4",
-	"xR6m+ntC1AZ7mJEY8ALTEHtYwPeUCgjxQokUPCyDDcREH7niIiZKr2Pq/Tvs4ZgyGqcxXsw9rLYJ2J9g",
-	"DQLvdp659JLGVDXp+ZX80DsRS+MlCMRXaEOCB4kURwJUKhh6c3ZyNp/P3xakfk9BbEtaI3OwS14IK5JG",
-	"Ci/O5nOvhVh7pfl57tB+1kn7zQNNmqT/1iRZPtAELWHFBaCARxEEirI1EiDTSMkuDvSudgZaye/H+krw",
-	"ZQTxb+boOsnZj/sVwPynTwV+ErDCC/yHWamEM/urnLkkaJKuCXugbD1YA4RdjwQEXISvSBcyRvapQwv9",
-	"r0AxbtJlTKWknLX5hfLXF/cO5dWDNUQWW16RdpR87FOQGvmvQDluJQhtr1da0A3K9a9H9hn6CmYdxi7f",
-	"YwLZxYawNVykQgBTetVntuLX8D0FaVSFhCHVZJLoSvAEhKIg8WJFIgkeTpxPTziVIIbQYRAp2bizG+8L",
-	"4PjyGwQK77wu4mTCmYS91DWPE0AU6IjjMFjloVSd0abmYQVS+QGR4AdJUtm/3Cotu2yLVIKydXWH+qEG",
-	"7KgB51DbCt9E4J4h1gYNJlGqXV49/1sarsHnqUpSNQg0/gjikcLv+4jSV3/J12qtVyEIMVIuLyTJgqf7",
-	"DgwvqVTdGAY8ZapVY5taarIpvZYqiOVYELPziBBk2+DCHu1l5HSx8sWRX5UNvd9X1KZWBSshUXBivrbg",
-	"TsMJhhpDzMW2vvHjh1a8pCIqNeQ1Li/tz59ER4PVVcSJKqmwEVmv1Ebosyzp7Fclkz5UKSuY8ByIu8TT",
-	"rWUTeGzS1nbtJWHrkV7J0tKQSAdEHn4EkXv1AfBlsTbf1EVz3ShH0B8Rth5uhQagfdZnj2yllS4FEdtb",
-	"ETWTjy+JpRjdXl+iFRdIbQBpdfujRJHdhxLBVzSCU3QrARGGIE7UFlkAdYb1AJAgqlDKJKhTm9ldAlvr",
-	"ZOfdfN5itlkNMxK0XLqDqyNtYioaYDSZwO3qNgizYy+IgjUXFOREuQfFAYOFX716u1cPnCv2c7IdSX9i",
-	"d4+mvpBHhfLB8rHLvPL6Hs6ekevoMEyiyO/2Fh6WPBUB+GmbMX36oXSeHSEBKxDAAihMKqMcaU8MMTBj",
-	"J61phM4iZC8J2n/7UV7NNaJHi0MuI0kX4CNcZC4MB4kKTeVRbQx5DZR7ZPkMDztVU/fa1xAdHNofQgFn",
-	"kkpTkPIVivjvIDRcKAKlQEgPhXRNlfQQFyhlIQgZcAGy5mTPsvq5+NvTxaPWRbzA/70jJ/+bn/zVv//5",
-	"pzady9ouUx1aZ+rZn/toO9CMB8MFpKuMm3LbPjk5N/SlpNewplKBmFb0DglJTvHdEnX6aZpa697w6BHC",
-	"myJ3rbWjzK/IZoXGRZHcQWnNAqbFdocvz79+uvnqn19gD59fOJSWylN2ZS6IhGvTU2mpT4hs9znBBoIH",
-	"ELr8G1RmHSxzH1ELDkzSG1FYgpt4ZwVMxkCb0J0OYm/BHBDmCzBls8PbkvMICDOg6jI0a28NNq5WQbYE",
-	"bL2VRuCDEFwctF4vKahU7SbI7A9KxS3FFq+CVD/ihyuvnebjBOwHl9ruNX3ezTlahLaRUzQy8Ykpduqu",
-	"QdhopJcb1+Bc5ToHu/nnWi3Z5hm6C/6OirKJKpV+RFTmnpsaH2UF5PP8ReYB/c4iMl/QnUMNaxaMa3Ec",
-	"r0tQYbjOXoaqi/14d6amRdVcnk6K8/FDPcPpEs/IiqR0MHVD0N9RwEPQNa7xIuhNTH6gM/Qr/eVtIwX7",
-	"8Jc//fnjXiJVBP4D48FDFvLqytyebLpezYDTh/ikPO5ozZ3brH88hhbph/AIkf7WYfC2M5FXYb29k7L5",
-	"4TSIpudr1cu9KrFdALxU/33QWMXk0UV+aFPkicRJc4wfk6R7457Y5yaqzQlCPeyV93VyViksXqCSOYRK",
-	"dQfwYmdzbMjo99T26noqynodudkmG2C1erLmy973VpPnJ/+xBeVJe0WpfSoEqaBqe6PZt+iuqIAlkXCe",
-	"2hHoEogA8bcc6n/++2s+bTWmbn4tz94oldjZJWUrbnyCjcF5bxNd2EoCXX+6+YrOrz6jN0ZqJHrr9CMW",
-	"eH56djo3WWkCjCQUL/D70/npe2x43BhSZyRVm1lgp2d+bn9rMMqhNYaobMyP/w6qNmUzI1prS+awd/O5",
-	"VS6mwKoXSZKIBuaM2TdpGy7DprhdAz0DTK2t+y8riDSOiU6ANKUoYylTGU3szrAdbJqcXenPbbyZeP4L",
-	"D7eHY6tvBr2rWowSKeyOCXHvyLkH6Ezj8eKurut397t7VxL2ijZh7LxM90RW/5uMmcsWxbviumDJVh1H",
-	"LPXGyAtLotEDOQj4+akGdot4tSXfZeaNAcAxDb172jDU1PN2s8OcYbaY/nbxmQ+bjUMsnzzetRNcLpkV",
-	"L/l23qC19jWSXtz2/MaIx33d0ggy7fuKAmX0TlPw1l781AvjrCp+c0JDlJXRHqKhh3Q55CFTwr1taexr",
-	"HTyasjSeBwzREb3BPqw0MaDTx+jDj+X2G89xXtjDVKbdB/EutgIzuCJdMSPTBSwNb/ZEw90+68si7Xjr",
-	"+xzioyvapLzD4FGGuGL23YVCPls/pottzO+HMqOpT8kaUESlLVBm7qhpT/x4ibAxia2ChwpHsyftHXcD",
-	"GJuktZVWzP3xkZmkvXkoLRU4e4Hch0o2VBuNiPsGekAgrbz9PiqC9SnhUPRyrAxwteZ4F3jVvvxoDGsv",
-	"hQfAWH8j3ZUjON24KU/1D52yaL8KYdtOp504ML8a2r1oPy6EME1uO3K2vcRkjeYDpGwDpyxm33Gzso7Z",
-	"0lCzcd+wl4HG+bo3laiOE59hRMdOKzrmnuORcjy0+aj6y2ebrB0pua1OP144sa0NAg6Z2hIkeZSaUwzQ",
-	"2o8MyRKcFtI4Paz804mj6uHktlqtg+NCMqs+c+lD58Z9rvKaMeocHYzCS5ZPUPL3PFYjxWPOtRnu4Bne",
-	"3e/+HwAA//9bCkKajjkAAA==",
+	"H4sIAAAAAAAC/8xbe3PbuBH/Khj0ZprM0ZacpGmr/3yetE3rXFw7ns7U43JgciUhIgEGAH1RM/ruNwD4",
+	"AJ8iacnjvxJLWGD3tw/sLlY/cMDjhDNgSuLFD5wQQWJQIMxf/yDB5mOo/xeCDARNFOUML8zniIbAFF1S",
+	"EKfYw1R/nhC1xh5mJAa8wDTEHhbwLaUCQrxQIgUPy2ANMdFbLrmIidLrmHr7Bns4pozGaYwXcw+rbQL2",
+	"K1iBwLudZw69pDFVTX4+ke+aErE0fgCB+BKtSbCRSHEkQKWCoVdnJ2fz+fx1weq3FMS25DUyG7vshbAk",
+	"aaTw4mw+91qYtUear+cO72edvN9saNJk/dcmy3JDE/QASy4ABTyKIFCUrZAAmUZKdkmgqdoFaGW/H+sr",
+	"wR8iiH81W9dZzr7cbwDmnz4T+EnAEi/wH2alEc7st3LmsqBZuiZsQ9lqsAUIux4JCLgIX5AtZILsM4cW",
+	"/l+AYdykDzGVknLWFhfKb589OpRHD7YQWZC8IOso5dhnIDX2X4Bx3EoQ2l+vtKIbnOtvjxwz9BHMBoxd",
+	"TmMusos1YSu4SIUApvSqj2zJr+FbCtKYCglDqtkk0ZXgCQhFQeLFkkQSPJw4H/3AqQQxhA+DSCnGnSW8",
+	"L4DjD18hUHjndTEnE84k7OWuY7uXKeQBpBNAFOj71JGsynzpGKMDiYcVSOUHRIIfJEmF/mGrtGVmJFIJ",
+	"ylZVCvVdDaCoIeZw24rbRLN4gj4bPJg0sHZ4df+vabgCn6cqSdUg0PgjiEcKv+1jSh/9OV+rfVqFIMRI",
+	"vTyTJguZ7jswvKRSdWMY8JSpVottWqnJFfVaqiCWY0HM9iNCkG1DCru1l7HTJcpnR39VMTS9r6hNHAtR",
+	"QqLgxHzagjsNJzhqDDEX2zrh+3eteElFVGrYaxxe+p8/iY+GqMuIE1VyYfMNvVI7oc+ylLrflExyVOWs",
+	"EMJzIO5ST7eVTZCxyVvbsZeErUZGJctLQyMdEHn4EUQe1QfAl2USOVEXz3WnHMF/RNhquBcagPZ5n92y",
+	"lVf6IIjY3oqomVp9TizH6Pb6Ei25QGoNSJvbHyWKLB1KBF/SCE7RrQREGII4UVtkAdT54wYgQVShlElQ",
+	"pzZvvQS20qncm/m8xW0/cUYV139NxE8RufG/pZDCPuy+ELn5t16oryEDIlck8p0UeGDgtHQammEUNfW4",
+	"5G1MeK5MbVrMqtqRQOUeMbhe1mFJRQMCTeYkdnUPwxdEwYoLCnKiroNig8EOUz16u9d3nCP2S7IdyX9i",
+	"qUdzX+ijwvlg/dhlXnl8j2RPyA916kKiyO+OsB6WPBUB+GlbAPrwXenKK0ICliCABVCEoYxzpG8viIGZ",
+	"2NKaeunMS/ayoO88P8rr+8aN23KJlbdvF+AjrpVcGQ4SFZ7KrdoE8hoo9+jyCbfSVEvd619DbHBoxxAF",
+	"nEkqTYuCL1HEfwOh4UIRKAVCeiikK6qkh7hAKQtByIALkLWL6SzrqBR/ezghegN96v/uyMn/5yd/9e9/",
+	"/qnN5rJG3NSA1pmu9+eL2g+04MFwBenK7KYk26cn54S+NP4aVlQqENM6BEOuJKcd03Lr9PM0tT9wDaYW",
+	"nb7BDY8eIbwpCoZah9N8i2wqbmIcySOcNk1gWu93+PL8y4ebL/75Bfbw+YUjaml9ZaPvgkjNr+m6NYpC",
+	"ItuDVrCGYANC19yDatuDlUsjCvCBlVHjGpfgVjtZ1ZgJ0GY1TlO6t0sREOYLax+ObA+cR0CYAVXX/lnH",
+	"dLB3tiqy5cbXpDQCH4Tg4qBNkpKDSqvE3FL7b7XilILEqyDVj/jhehq1ZH4k9oP7G9V0vTs8OluL0HbP",
+	"it44PjEVZj00CHud6eUmNDhHucHBEv9cK+DbIkN3l6WjjG+iSqUfEZXF96bFR1nV/rR4kUVAv7Nyzxd0",
+	"J2HDOjTj+krHa81UBK6Ll6HqYj8+nKlp13KuTydHev+uniJ1qWdkSVMGmLoj6M9RwENAiiMTRdCrmHxH",
+	"Z+gT/eV1I4d795c//fn9XiZVBP6G8WCTXXl1Y27PVt2oZsDpQ3xSIni0jlq16TGyCAAWUrbyFZGbob0R",
+	"kTI2lsa2QIZT1JVUYbPOQnX7Nohus3eNMeqSfgiPEOnPOmKi7ZjllW5vT69syjmNy+k5cfVwr8psFwDP",
+	"9S406J3P1CpFCm3LkInMSbONH5Okm3BPeuDm8s2XrXpmUJ7XKVmleHuGavEQJtWd4xSUzcd6Rr+ltofc",
+	"U7XXa/X1NlkDq9XstXD/trdiPz/5ry3aT9qrdn3tQJAKqrY3WnyL7pIKeCASzlM7ePAARID4Ww71P//z",
+	"JZ9xMK5uvi33XiuV2IkBmgXaLE3Je+7owhZb6PrDzRd0fvURvTJaI9Frp+ezwPPTs9O5SdwTYCSheIHf",
+	"ns5P32Ij49qwOiOpWs8C+6rr5/63AmMc2mKIyoZr8N9B1V5/zWCE9SWz2Zv53BoXU2DNiyRJRAOzx+yr",
+	"tE2tYbMTXQ/NBpjac8O/rCLSOCY6R9ScokykzGSyNn1CVLBuSnalP26TzaQ8v/Bwezix+iY/dlWPUSKF",
+	"3TEh7h306AE6s3i8uKvb+t397t7VhD2iTRk7L7M9kfVYTJrAZYvhXXFd02WrjqOWevPpmTXR6DMdBPx8",
+	"VwO7Rbz67NHl5o1HlmM6eveLzlBXz1v6jnBG2GIqoUvOfAjCBMRy0PiuneFyyayYn915g9baGUC9uG3o",
+	"zajHnSlrXDLtdEUNN5rS9ARqc3b13kHWOHh1QkOUdRo8REMP6YrRQ6bKfd3yeKJt8GjG0hhbGWIjmsCO",
+	"M5s7oDPG6M2PFfYbY2LPHGEqUxgHiS62SDW4IgVSIdMoLR1v9oOGu33el920473vY4iPbmiT8g6DR3nF",
+	"FTMZXSjkMx/HDLGNuZKhwmjuU7ICFFFpC5RZXExZ9ElVzmIcU66WiY+hkpVioJAoYmVznyr33I3PcSVO",
+	"UlkhQ0Wi2Q8d+XcDBJvkkZVO3P3xkZnkmXmaUDpn9puGPlSyR9nRiLi/qhiQJFR+TXJUBOuvzEPRy7Ey",
+	"wNXeRrrAqz7LjMaw9tuDATDWf3XRlf84zdgpP/45dDqm7wwI2yidbvLA3HFoZ6Z9uxDCNLntyEf3MpO9",
+	"MxwgHR34yGbojptxdjwtDnUb91cx5SXqfLo3Taq+Jj/BiY6dMnU8e49HyonQdaBmznt5X7PALnq5WNXH",
+	"Qg5U79u3LeJg6cCo+kGz+fyR6p/qG+Iz1z6157RDVj8ESR6lqgDajOIOSLacLuM4E638pu2oJjq58zq4",
+	"43pIEI7VqX0RLdqj9mZrPVnXgmfV4cA+Y75xh/xeskl3PgaOMm9Zzt3lU5AWffGYS22ea/EM7+53vwcA",
+	"AP///FvTE9ZAAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/restapi/main_test.go
+++ b/restapi/main_test.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"database/sql"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/yosupo06/library-checker-judge/database"
 	restapi "github.com/yosupo06/library-checker-judge/restapi/internal/api"
 )
 
@@ -35,5 +37,51 @@ func TestGetLangList_Unit(t *testing.T) {
 	// Basic field sanity check
 	if resp.Langs[0].Id == "" || resp.Langs[0].Name == "" || resp.Langs[0].Version == "" {
 		t.Fatalf("invalid first lang: %+v", resp.Langs[0])
+	}
+}
+
+func TestGetMonitoring(t *testing.T) {
+	db := setupTestDB(t)
+	if err := database.RegisterUser(db, "alice", "uid-monitoring"); err != nil {
+		t.Fatalf("register user: %v", err)
+	}
+	if err := database.SaveProblem(db, database.Problem{
+		Name:             "aplusb_monitoring",
+		Title:            "A + B",
+		SourceUrl:        "https://example.com/aplusb",
+		Timelimit:        2000,
+		TestCasesVersion: "v1",
+		Version:          "1",
+		OverallVersion:   "1",
+	}); err != nil {
+		t.Fatalf("save problem: %v", err)
+	}
+	if _, err := database.SaveSubmission(db, database.Submission{
+		ProblemName: "aplusb_monitoring",
+		Lang:        "cpp",
+		Status:      "AC",
+		Source:      "#include <bits/stdc++.h>\nint main(){return 0;}",
+		MaxTime:     1,
+		MaxMemory:   1,
+		UserName:    sql.NullString{String: "alice", Valid: true},
+	}); err != nil {
+		t.Fatalf("save submission: %v", err)
+	}
+
+	r := chi.NewRouter()
+	_ = restapi.HandlerFromMux(newRESTHandler(&server{db: db}), r)
+	req := httptest.NewRequest(http.MethodGet, "/monitoring", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /monitoring status=%d body=%s", w.Code, w.Body.String())
+	}
+	var resp restapi.MonitoringResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp.TotalUsers != 1 || resp.TotalSubmissions != 1 {
+		t.Fatalf("unexpected monitoring response: %+v", resp)
 	}
 }

--- a/restapi/openapi/openapi.yaml
+++ b/restapi/openapi/openapi.yaml
@@ -284,26 +284,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/UserInfoResponse'
-    patch:
-      summary: Change user info
-      operationId: patchUserInfo
-      security:
-        - firebaseAuth: []
-      parameters:
-        - $ref: '#/components/parameters/UserNamePath'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ChangeUserInfoRequest'
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ChangeUserInfoResponse'
   /users/{name}/statistics:
     get:
       summary: Get user solved statistics
@@ -655,17 +635,6 @@ components:
           $ref: '#/components/schemas/User'
       required: [user]
     ChangeCurrentUserInfoResponse:
-      type: object
-      additionalProperties: false
-      properties: {}
-    ChangeUserInfoRequest:
-      type: object
-      additionalProperties: false
-      properties:
-        user:
-          $ref: '#/components/schemas/User'
-      required: [user]
-    ChangeUserInfoResponse:
       type: object
       additionalProperties: false
       properties: {}

--- a/restapi/openapi/openapi.yaml
+++ b/restapi/openapi/openapi.yaml
@@ -19,6 +19,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RankingResponse'
+  /monitoring:
+    get:
+      summary: Get monitoring data
+      operationId: getMonitoring
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MonitoringResponse'
   /problems:
     get:
       summary: Get problems
@@ -139,6 +150,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SubmissionInfoResponse'
+  /submissions/{id}/rejudge:
+    post:
+      summary: Rejudge a submission
+      operationId: postRejudge
+      security:
+        - firebaseAuth: []
+      parameters:
+        - $ref: '#/components/parameters/SubmissionId'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RejudgeResponse'
   /hacks:
     get:
       summary: List hacks
@@ -258,6 +284,26 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/UserInfoResponse'
+    patch:
+      summary: Change user info
+      operationId: patchUserInfo
+      security:
+        - firebaseAuth: []
+      parameters:
+        - $ref: '#/components/parameters/UserNamePath'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChangeUserInfoRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChangeUserInfoResponse'
   /users/{name}/statistics:
     get:
       summary: Get user solved statistics
@@ -612,6 +658,17 @@ components:
       type: object
       additionalProperties: false
       properties: {}
+    ChangeUserInfoRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        user:
+          $ref: '#/components/schemas/User'
+      required: [user]
+    ChangeUserInfoResponse:
+      type: object
+      additionalProperties: false
+      properties: {}
     UserInfoResponse:
       type: object
       additionalProperties: false
@@ -659,6 +716,10 @@ components:
           format: int32
           minimum: 0
       required: [id]
+    RejudgeResponse:
+      type: object
+      additionalProperties: false
+      properties: {}
     SubmissionOverview:
       type: object
       properties:
@@ -735,3 +796,30 @@ components:
           items:
             $ref: '#/components/schemas/SubmissionCaseResult'
       required: [overview, source, can_rejudge]
+    TaskQueueInfo:
+      type: object
+      additionalProperties: false
+      properties:
+        pending_tasks:
+          type: integer
+          format: int32
+        running_tasks:
+          type: integer
+          format: int32
+        total_tasks:
+          type: integer
+          format: int32
+      required: [pending_tasks, running_tasks, total_tasks]
+    MonitoringResponse:
+      type: object
+      additionalProperties: false
+      properties:
+        total_users:
+          type: integer
+          format: int32
+        total_submissions:
+          type: integer
+          format: int32
+        task_queue:
+          $ref: '#/components/schemas/TaskQueueInfo'
+      required: [total_users, total_submissions, task_queue]


### PR DESCRIPTION
## Summary
- add REST endpoints for monitoring and rejudge
- keep self user updates on the existing `PATCH /auth/current_user` endpoint instead of adding a duplicate `PATCH /users/{name}` API
- regenerate OpenAPI server code and add REST handler tests

## Tests
- go test ./... in `restapi/`