### PR TITLE
fix(judge): serve fake GCS with local public host

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -77,6 +77,8 @@ services:
       - 0.0.0.0
       - -port
       - "4443"
+      - -public-host
+      - localhost:4443
     ports:
       - 4443:4443
     healthcheck:


### PR DESCRIPTION
## Summary
- configure fake-gcs-server with `-public-host localhost:4443`
- make local public object URLs match the production-style `/<bucket>/<object>` shape used by the frontend

## Verification
- Confirmed the frontend works locally with yosupo06/library-checker-frontend#287
- Existing `go.work.sum` local changes were not included