### PR TITLE
[codex] Remove judge dummy image

### DIFF
--- a/packer/base/build.pkr.hcl
+++ b/packer/base/build.pkr.hcl
@@ -16,17 +16,17 @@ packer {
 }
 
 source "googlecompute" "judge" {
-  project_id = "${var.env}-library-checker-project"
-  source_image_family = "ubuntu-2204-lts"
-  zone = "us-east1-b"
-  network = "main"
-  subnetwork = "main"
-  machine_type = "c2d-standard-8"
-  disk_size = 50
-  ssh_username = "ubuntu"
+  project_id              = "${var.env}-library-checker-project"
+  source_image_family     = "ubuntu-2204-lts"
+  zone                    = "asia-northeast1-b"
+  network                 = "main"
+  subnetwork              = "main"
+  machine_type            = "c2d-standard-8"
+  disk_size               = 50
+  ssh_username            = "ubuntu"
   temporary_key_pair_type = "ed25519"
-  image_name = "${var.image_name}"
-  preemptible = true
+  image_name              = "${var.image_name}"
+  preemptible             = true
 }
 
 build {
@@ -67,7 +67,7 @@ build {
 
   # install crun
   provisioner "file" {
-    source = "crun-install.sh"
+    source      = "crun-install.sh"
     destination = "/tmp/crun-install.sh"
   }
   provisioner "shell" {
@@ -78,7 +78,7 @@ build {
 
   # install docker
   provisioner "file" {
-    source = "docker-install.sh"
+    source      = "docker-install.sh"
     destination = "/tmp/docker-install.sh"
   }
   provisioner "shell" {
@@ -89,7 +89,7 @@ build {
 
   # build our images
   provisioner "file" {
-    source = "../../langs"
+    source      = "../../langs"
     destination = "/tmp"
   }
   provisioner "shell" {
@@ -109,7 +109,7 @@ build {
     ]
   }
   provisioner "file" {
-    source = "docker-daemon.json"
+    source      = "docker-daemon.json"
     destination = "/tmp/daemon.json"
   }
   provisioner "shell" {
@@ -121,11 +121,11 @@ build {
 
   # prepare systemctl files
   provisioner "file" {
-    source = "prepare-docker.service"
+    source      = "prepare-docker.service"
     destination = "/tmp/prepare-docker.service"
   }
   provisioner "file" {
-    source = "prepare-docker.sh"
+    source      = "prepare-docker.sh"
     destination = "/tmp/prepare-docker.sh"
   }
   provisioner "shell" {
@@ -137,7 +137,7 @@ build {
   }
 
   provisioner "file" {
-    source = "docker-drop-in.conf"
+    source      = "docker-drop-in.conf"
     destination = "/tmp/docker-drop-in.conf"
   }
   provisioner "shell" {

--- a/packer/judge/build.pkr.hcl
+++ b/packer/judge/build.pkr.hcl
@@ -27,8 +27,8 @@ locals {
   })
   parsed_judge_service = templatefile("judge.service.pkrtpl", {
     storage_private_bucket = var.storage_private_bucket
-    storage_public_bucket = var.storage_public_bucket
-    pg_user = var.pg_user
+    storage_public_bucket  = var.storage_public_bucket
+    pg_user                = var.pg_user
   })
 }
 
@@ -42,18 +42,18 @@ packer {
 }
 
 source "googlecompute" "judge" {
-  project_id = "${var.env}-library-checker-project"
-  source_image_family = "v3-${var.env}-base-image"
-  zone = "us-east1-b"
-  network = "main"
-  subnetwork = "main"
-  machine_type = "c2d-standard-8"
-  disk_size = 50
-  ssh_username = "ubuntu"
+  project_id              = "${var.env}-library-checker-project"
+  source_image_family     = "v3-${var.env}-base-image"
+  zone                    = "asia-northeast1-b"
+  network                 = "main"
+  subnetwork              = "main"
+  machine_type            = "c2d-standard-8"
+  disk_size               = 50
+  ssh_username            = "ubuntu"
   temporary_key_pair_type = "ed25519"
-  image_name = "${var.image_family}-{{timestamp}}"
-  image_family = "${var.image_family}"
-  preemptible = true
+  image_name              = "${var.image_family}-{{timestamp}}"
+  image_family            = "${var.image_family}"
+  preemptible             = true
 }
 
 build {
@@ -75,7 +75,7 @@ build {
     ]
   }
   provisioner "file" {
-    content = local.parsed_cloudsql_service
+    content     = local.parsed_cloudsql_service
     destination = "/tmp/cloudsql.service"
   }
   provisioner "shell" {
@@ -87,11 +87,11 @@ build {
 
   # send judge
   provisioner "file" {
-    source = "../../judge/judge"
+    source      = "../../judge/judge"
     destination = "/tmp/judge"
   }
   provisioner "file" {
-    content = local.parsed_judge_service
+    content     = local.parsed_judge_service
     destination = "/tmp/judge.service"
   }
   provisioner "shell" {

--- a/terraform/compute.tf
+++ b/terraform/compute.tf
@@ -1,25 +1,6 @@
-data "google_compute_image" "debian" {
-  family  = "debian-12"
-  project = "debian-cloud"
-}
-
-resource "google_compute_image" "judge_dummy" {
-  name   = "v3-judge-image-0000"
-  family = local.judge_image_family
-
-  source_image = data.google_compute_image.debian.id
-
-  // Seed the family for the very first apply; keep the resolved Debian image pinned
-  lifecycle {
-    ignore_changes = [source_image]
-  }
-}
-
-
 data "google_compute_image" "judge" {
   family      = local.judge_image_family
   most_recent = true
-  depends_on  = [google_compute_image.judge_dummy]
 }
 
 resource "google_compute_instance_template" "judge" {


### PR DESCRIPTION
## Summary

- Remove the Terraform-managed `v3-judge-image-0000` dummy image from the judge image family.
- Make the judge instance template resolve only real images from the configured `v3-judge-image` family.
- Move Packer base/judge image build VMs from `us-east1-b` to `asia-northeast1-b` to avoid the current capacity issue and align with the judge MIG zone.

## Why

The dummy image can be pruned and later recreated by Terraform, making it the newest image in the family. Because the instance template uses `most_recent = true`, that can cause judge VMs to boot from the empty Debian seed image instead of a Packer-built judge image.

The current Packer build is also failing to create its temporary `c2d-standard-8` VM in `us-east1-b` due to GCE capacity exhaustion. `asia-northeast1-b` already has the `main` subnet and is the zone used by the judge managed instance group.

## Validation

- `terraform fmt -check`
- `terraform validate`
- `packer fmt -check packer/base/build.pkr.hcl packer/judge/build.pkr.hcl`
- `packer validate -var 'env=prod' -var 'image_name=validate-image' .` in `packer/base`
- `go build .` in `judge`
- `packer validate -var 'env=prod' -var 'image_family=v3-judge-image' -var 'storage_private_bucket=private' -var 'storage_public_bucket=public' -var 'db_connection_name=project:region:instance' -var 'pg_user=judge' .` in `packer/judge`