### PR TITLE
[codex] skip image report comments on fork PRs

### DIFF
--- a/.github/workflows/test-langs.yml
+++ b/.github/workflows/test-langs.yml
@@ -85,7 +85,11 @@ jobs:
         markdown_path.write_text("\n".join(lines) + "\n")
         PY
 
+    - name: Add image size report to job summary
+      run: cat report/langs-image-sizes.md >> "$GITHUB_STEP_SUMMARY"
+
     - name: Create or update PR comment
+      if: github.event.pull_request.head.repo.full_name == github.repository
       uses: peter-evans/create-or-update-comment@v3
       with:
         issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
- Add the language image size report to the GitHub Actions job summary.
- Skip the PR comment step for fork-based pull requests, where the default `GITHUB_TOKEN` is read-only.

## Background
Fork PRs currently fail in `Test Langs / image-size-report` when `peter-evans/create-or-update-comment` tries to create a PR comment and receives `Resource not accessible by integration`.

## Validation
- Ran `git diff --check -- .github/workflows/test-langs.yml`.