### PR TITLE
[codex] add Deno JavaScript and TypeScript languages

### DIFF
--- a/executor/langs_aplusb_test.go
+++ b/executor/langs_aplusb_test.go
@@ -50,6 +50,10 @@ func samplePathFor(langID string) (string, map[string]string) {
 		return "sources/aplusb/ac.rs", nil
 	case "java":
 		return "sources/aplusb/ac.java", nil
+	case "javascript":
+		return "sources/aplusb/ac.js", nil
+	case "typescript":
+		return "sources/aplusb/ac.ts", nil
 	case "go":
 		return "sources/aplusb/go/ac.go", nil
 	case "haskell":

--- a/executor/sources/aplusb/ac.js
+++ b/executor/sources/aplusb/ac.js
@@ -1,0 +1,3 @@
+const inputText = await Deno.readTextFile("/dev/stdin");
+const input = inputText.trim().split(/\s+/).map(Number);
+console.log(input[0] + input[1]);

--- a/executor/sources/aplusb/ac.ts
+++ b/executor/sources/aplusb/ac.ts
@@ -1,0 +1,5 @@
+export {};
+
+const inputText: string = await Deno.readTextFile("/dev/stdin");
+const input = inputText.trim().split(/\s+/).map(Number);
+console.log(input[0] + input[1]);

--- a/langs/Dockerfile.DENO
+++ b/langs/Dockerfile.DENO
@@ -1,0 +1,13 @@
+FROM rust:alpine AS init-builder
+WORKDIR /library-checker-init
+COPY init /library-checker-init
+RUN cargo build --release --target=x86_64-unknown-linux-musl
+
+FROM denoland/deno:2.7.14
+
+USER root
+ENTRYPOINT []
+
+COPY --from=init-builder /library-checker-init/target/x86_64-unknown-linux-musl/release/library-checker-init /usr/bin
+
+LABEL library-checker-image=true

--- a/langs/build.py
+++ b/langs/build.py
@@ -24,6 +24,7 @@ IMAGES = {
     "ruby": ("RUBY", "library-checker-images-ruby"),
     "swift": ("SWIFT", "library-checker-images-swift"),
     "nim": ("NIM", "library-checker-images-nim"),
+    "deno": ("DENO", "library-checker-images-deno"),
 }
 
 

--- a/langs/langs.toml
+++ b/langs/langs.toml
@@ -56,6 +56,22 @@
     compile = ["javac", "Main.java"]
     exec = ["java", "-Xss1G", "-Xmx1G", "Main"]
 [[langs]]
+    id = "javascript"
+    name = "JavaScript"
+    version = "Deno 2.7.14"
+    source = "main.js"
+    image_name = "library-checker-images-deno"
+    compile = ["deno", "check", "main.js"]
+    exec = ["deno", "run", "--allow-all", "main.js"]
+[[langs]]
+    id = "typescript"
+    name = "TypeScript"
+    version = "Deno 2.7.14"
+    source = "main.ts"
+    image_name = "library-checker-images-deno"
+    compile = ["deno", "check", "main.ts"]
+    exec = ["deno", "run", "--allow-all", "main.ts"]
+[[langs]]
     id = "python3"
     name = "Python3"
     version = "python3.10 + numpy + scipy"

--- a/langs/langs_test.go
+++ b/langs/langs_test.go
@@ -7,7 +7,8 @@ import (
 func TestAllSupportedLangs(t *testing.T) {
 	expectedLangs := []string{
 		"cpp", "cpp-func", "rust", "haskell", "csharp", "lisp",
-		"python3", "pypy3", "d", "java", "go", "crystal", "ruby",
+		"python3", "pypy3", "d", "java", "javascript", "typescript",
+		"go", "crystal", "ruby",
 	}
 
 	for _, langID := range expectedLangs {


### PR DESCRIPTION
## Summary
- Add a Deno-based language image for judge execution.
- Register JavaScript and TypeScript language entries using Deno 2.7.14.
- Add A+B executor samples for JavaScript and TypeScript.

## Motivation
Closes #562 by adding JavaScript and TypeScript support through Deno.

## Validation
- `python3 langs/build.py deno`
- `go test ./langs`
- `go test -v -tags=langs_all ./executor -run 'TestAllLangsAplusb/(javascript|typescript)$'`