### PR TITLE
[codex] Update GHC to 9.6.7

### DIFF
--- a/langs/Dockerfile.HASKELL
+++ b/langs/Dockerfile.HASKELL
@@ -1,27 +1,27 @@
-FROM rust:alpine as init-builder
+FROM rust:alpine AS init-builder
 WORKDIR /library-checker-init
 COPY init /library-checker-init
 RUN cargo build --release --target=x86_64-unknown-linux-musl
 
-FROM haskell:9.4.4-slim
+FROM haskell:9.6.7-slim AS haskell-builder
 
 RUN cabal update && cabal install --lib \
     QuickCheck-2.14.2 \
-    array-0.5.4.0 \
+    array-0.5.8.0 \
     attoparsec-0.14.4 \
     bitvec-1.1.3.0 \
-    bytestring-0.11.4.0 \
+    bytestring-0.11.5.4 \
     containers-0.6.7 \
-    deepseq-1.4.8.0 \
+    deepseq-1.4.8.1 \
     exceptions-0.10.7 \
     extra-1.7.12 \
     fgl-5.8.1.1 \
     hashable-1.4.2.0 \
     heaps-0.4 \
     integer-logarithms-1.0.3.1 \
-    lens-5.2 \
-    linear-base-0.3.0 \
-    massiv-1.0.3.0 \
+    lens-5.2.3 \
+    linear-base-0.7.0 \
+    massiv-1.0.5.0 \
     mono-traversable-1.0.15.3 \
     mtl-2.3.1 \
     mutable-containers-0.3.4.1 \
@@ -44,12 +44,35 @@ RUN cabal update && cabal install --lib \
     vector-algorithms-0.9.0.1 \
     vector-stream-0.1.0.0 \
     vector-th-unbox-0.2.2 \
+ && find /opt/ghc -type f \( -name '*_p.a' -o -name '*.p_hi' \) -delete \
+ && rm -rf /opt/ghc/9.6.7/share/doc \
  && rm -rf /root/.cabal/logs \
            /root/.cabal/packages \
            /root/.cache \
            /root/.ghcup/cache \
            /root/.ghcup/logs
 
+FROM debian:bullseye-slim
+
+ENV LANG=C.UTF-8
+ENV PATH=/root/.cabal/bin:/root/.local/bin:/opt/ghc/9.6.7/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        g++ \
+        gcc \
+        libc6-dev \
+        libffi-dev \
+        libgmp-dev \
+        libnuma-dev \
+        libtinfo-dev \
+        make \
+        zlib1g-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=haskell-builder /opt/ghc/9.6.7 /opt/ghc/9.6.7
+COPY --from=haskell-builder /root/.ghc /root/.ghc
+COPY --from=haskell-builder /root/.local/state/cabal/store /root/.local/state/cabal/store
 COPY --from=init-builder /library-checker-init/target/x86_64-unknown-linux-musl/release/library-checker-init /usr/bin
 
 LABEL library-checker-image=true

--- a/langs/langs.toml
+++ b/langs/langs.toml
@@ -90,7 +90,7 @@
 [[langs]]
     id = "haskell"
     name = "GHC"
-    version = "ghc 9.0.2"
+    version = "ghc 9.6.7"
     source = "main.hs"
     image_name = "library-checker-images-haskell"
     compile = ["ghc", "main.hs", "-O2"]


### PR DESCRIPTION
## Summary

- Update the Haskell language image from GHC 9.4.4 to GHC 9.6.7.
- Update Haskell package pins that are incompatible with GHC 9.6.7 / `base-4.18`.
- Fix the displayed GHC version in `langs.toml` from `ghc 9.0.2` to `ghc 9.6.7`.
- Rebuild the final Haskell image from `debian:bullseye-slim`, copying only the cleaned GHC installation and installed package store from the Haskell builder stage.
- Remove GHC profiling artifacts (`*_p.a`, `*.p_hi`) and GHC docs from the final image path.

This intentionally does not add LLVM or change the default Haskell compile command. That can be handled separately as an optional backend follow-up.

## Validation

- `go test ./...` in `langs/`
- `docker build -f langs/Dockerfile.HASKELL -t library-checker-images-haskell:test-ghc-967-multistage langs`
- `docker run --rm library-checker-images-haskell:test-ghc-967-multistage sh -c 'find /opt/ghc -type f \( -name "*_p.a" -o -name "*.p_hi" \) | wc -l; test ! -d /opt/ghc/9.6.7/share/doc; ghc --version'`
- `docker run --rm library-checker-images-haskell:test-ghc-967-multistage sh -c 'printf "%s\n" "import qualified Data.Vector as V" "import qualified Data.ByteString.Char8 as BS" "main = print (V.sum (V.fromList [1 :: Int, 2, 3]) + BS.length (BS.pack \"abc\"))" > /tmp/main.hs && ghc /tmp/main.hs -O2 -o /tmp/main && /tmp/main'`

## Image size

Local amd64 build size changed from about `4.15GB` before cleanup to about `2GB` after the multi-stage final image change.