### PR TITLE
[codex] fix judge status priority

### DIFF
--- a/judge/judge_test.go
+++ b/judge/judge_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/yosupo06/library-checker-judge/langs"
 	"github.com/yosupo06/library-checker-judge/storage"
@@ -193,4 +194,72 @@ func TestAplusBCE(t *testing.T) {
 		t.Fatal("Success CompileChecker", result)
 	}
 	t.Cleanup(func() { _ = volume.Remove() })
+}
+
+func TestAggregateResultsStatusPriority(t *testing.T) {
+	tests := []struct {
+		name     string
+		statuses []string
+		want     string
+	}{
+		{
+			name:     "all accepted",
+			statuses: []string{"AC", "AC"},
+			want:     "AC",
+		},
+		{
+			name:     "tle has priority over earlier wa",
+			statuses: []string{"AC", "WA", "TLE"},
+			want:     "TLE",
+		},
+		{
+			name:     "re has priority over later wa",
+			statuses: []string{"RE", "WA", "AC"},
+			want:     "RE",
+		},
+		{
+			name:     "same priority keeps first status",
+			statuses: []string{"TLE", "RE", "PE"},
+			want:     "TLE",
+		},
+		{
+			name:     "unknown has priority over fail",
+			statuses: []string{"Unknown", "Fail"},
+			want:     "Unknown",
+		},
+		{
+			name:     "other has priority over ac",
+			statuses: []string{"AC", "Unknown"},
+			want:     "Unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results := make([]CaseResult, len(tt.statuses))
+			for i, status := range tt.statuses {
+				results[i] = CaseResult{Status: status}
+			}
+
+			got := aggregateResults(results)
+			if got.Status != tt.want {
+				t.Fatalf("aggregateResults(%v).Status = %q, want %q", tt.statuses, got.Status, tt.want)
+			}
+		})
+	}
+}
+
+func TestAggregateResultsMaxResources(t *testing.T) {
+	got := aggregateResults([]CaseResult{
+		{Status: "AC", Time: 10 * time.Millisecond, Memory: 100},
+		{Status: "WA", Time: 20 * time.Millisecond, Memory: 50},
+		{Status: "AC", Time: 15 * time.Millisecond, Memory: 200},
+	})
+
+	if got.Time != 20*time.Millisecond {
+		t.Fatalf("Time = %v, want %v", got.Time, 20*time.Millisecond)
+	}
+	if got.Memory != 200 {
+		t.Fatalf("Memory = %v, want 200", got.Memory)
+	}
 }

--- a/judge/submission.go
+++ b/judge/submission.go
@@ -276,7 +276,7 @@ func aggregateResults(results []CaseResult) CaseResult {
 		Memory: -1,
 	}
 	for _, res := range results {
-		if res.Status != "AC" {
+		if statusPriority(ans.Status) < statusPriority(res.Status) {
 			ans.Status = res.Status
 		}
 		if ans.Time < res.Time {
@@ -287,4 +287,19 @@ func aggregateResults(results []CaseResult) CaseResult {
 		}
 	}
 	return ans
+}
+
+func statusPriority(status string) int {
+	switch status {
+	case "AC":
+		return 0
+	case "WA":
+		return 1
+	case "RE", "TLE", "PE":
+		return 2
+	case "Fail", "IE":
+		return 3
+	default:
+		return 4
+	}
 }


### PR DESCRIPTION
## Summary

Fix submission result aggregation so the final status is selected by the configured judge status priority instead of by the last non-AC testcase result.

This implements the priority discussed in #8:

- AC: 0
- WA: 1
- RE / TLE / PE: 2
- Fail / IE: 3
- other statuses: 4

When multiple statuses have the same priority, the first observed status is kept. Max time and memory aggregation are unchanged.

## Validation

- `go test ./judge`
- `go test ./judge -run 'TestAggregateResults'`
