### PR TITLE
[codex] include frontend in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,3 +77,10 @@ jobs:
     secrets: inherit
     with:
       env: ${{ inputs.env }}
+
+  frontend-deploy:
+    needs: terraform-apply
+    uses: ./.github/workflows/frontend-deploy.yml
+    secrets: inherit
+    with:
+      env: ${{ inputs.env }}


### PR DESCRIPTION
## Summary

- Add the existing reusable frontend deploy workflow to the aggregate deploy workflow.
- Run frontend deploy after Terraform apply so full deploys also publish the Firebase-hosted frontend for the selected environment.

## Impact

Manual or reusable full deploy runs now include the frontend. The existing path-based prod frontend deploy remains unchanged.

## Validation

- Ran `git diff --check -- .github/workflows/deploy.yml`.