### PR TITLE
[codex] Add GHC LLVM backend language

### DIFF
--- a/langs/Dockerfile.HASKELL
+++ b/langs/Dockerfile.HASKELL
@@ -66,8 +66,11 @@ RUN apt-get update \
         libgmp-dev \
         libnuma-dev \
         libtinfo-dev \
+        llvm-11 \
         make \
         zlib1g-dev \
+ && ln -s /usr/bin/llc-11 /usr/local/bin/llc \
+ && ln -s /usr/bin/opt-11 /usr/local/bin/opt \
  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=haskell-builder /opt/ghc/9.6.7 /opt/ghc/9.6.7

--- a/langs/langs.toml
+++ b/langs/langs.toml
@@ -96,6 +96,14 @@
     compile = ["ghc", "main.hs", "-O2"]
     exec = ["./main"]
 [[langs]]
+    id = "haskell-llvm"
+    name = "GHC (LLVM)"
+    version = "ghc 9.6.7 + LLVM 11"
+    source = "main.hs"
+    image_name = "library-checker-images-haskell"
+    compile = ["ghc", "main.hs", "-O2", "-fllvm"]
+    exec = ["./main"]
+[[langs]]
     id = "nim"
     name = "Nim"
     version = "Nim 2.2.4"

--- a/langs/langs_test.go
+++ b/langs/langs_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestAllSupportedLangs(t *testing.T) {
 	expectedLangs := []string{
-		"cpp", "cpp-func", "rust", "haskell", "csharp", "lisp",
+		"cpp", "cpp-func", "rust", "haskell", "haskell-llvm", "csharp", "lisp",
 		"python3", "pypy3", "d", "java", "javascript", "typescript",
 		"go", "crystal", "ruby",
 	}


### PR DESCRIPTION
## Summary

- Install `llvm-11` in the final Haskell language image.
- Add unversioned `llc` and `opt` symlinks pointing to `llc-11` and `opt-11` so GHC can find the LLVM backend tools.
- Keep the existing `haskell` language on the native GHC backend with `ghc main.hs -O2`.
- Add a separate `haskell-llvm` language named `GHC (LLVM)` that uses `ghc main.hs -O2 -fllvm`.

## Validation

- `go test ./...` in `langs/`
- `docker build -f langs/Dockerfile.HASKELL -t library-checker-images-haskell:test-ghc-llvm langs`
- `docker run --rm library-checker-images-haskell:test-ghc-llvm sh -c 'ghc --version; llc --version | sed -n "1,2p"; opt --version | sed -n "1,2p"; command -v llc; command -v opt'`
- `docker run --rm library-checker-images-haskell:test-ghc-llvm sh -c 'printf "%s\n" "import qualified Data.Vector as V" "main = print (V.sum (V.fromList [1 :: Int, 2, 3]))" > /tmp/main.hs && ghc /tmp/main.hs -O2 -o /tmp/main && /tmp/main'`
- `docker run --rm library-checker-images-haskell:test-ghc-llvm sh -c 'printf "%s\n" "import qualified Data.Vector as V" "main = print (V.sum (V.fromList [1 :: Int, 2, 3]))" > /tmp/main.hs && ghc /tmp/main.hs -O2 -fllvm -o /tmp/main-llvm && /tmp/main-llvm'`
- `docker run --rm library-checker-images-haskell:test-ghc-llvm sh -c 'printf "%s\n" "main = print (1 + 2 :: Int)" > /tmp/main.hs && ghc /tmp/main.hs -O2 -o /tmp/main && /tmp/main && ghc /tmp/main.hs -O2 -fllvm -o /tmp/main-llvm && /tmp/main-llvm'`

## Image size

Local amd64 image size changed from about `2GB` to about `2.2GB`.