### PR TITLE
Update runtime base versions

### DIFF
--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '^1.24'
+          go-version: '^1.25'
       - uses: hashicorp/setup-terraform@v3
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
@@ -55,7 +55,7 @@ jobs:
             pg-pass:${{ inputs.env }}-library-checker-project/database-postgres-password/latest
 
       - run: |
-          curl -o cloud-sql-proxy https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.1.2/cloud-sql-proxy.linux.amd64
+          curl -o cloud-sql-proxy https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.21.3/cloud-sql-proxy.linux.amd64
           chmod +x ./cloud-sql-proxy
         working-directory: ./migrator
 

--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -50,7 +50,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "24"
       - run: npm install -g firebase-tools
 
       - run: npm ci

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/problems-deploy.yml
+++ b/.github/workflows/problems-deploy.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Download Cloud SQL Proxy
         working-directory: ./uploader
         run: |
-          curl -o cloud-sql-proxy https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.1.2/cloud-sql-proxy.linux.amd64
+          curl -o cloud-sql-proxy https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.21.3/cloud-sql-proxy.linux.amd64
           chmod +x ./cloud-sql-proxy
       - name: Deploy Shard ${{ matrix.shard }}
         working-directory: ./uploader
@@ -126,7 +126,7 @@ jobs:
       - name: Download Cloud SQL Proxy
         working-directory: ./uploader
         run: |
-          curl -o cloud-sql-proxy https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.1.2/cloud-sql-proxy.linux.amd64
+          curl -o cloud-sql-proxy https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.21.3/cloud-sql-proxy.linux.amd64
           chmod +x ./cloud-sql-proxy
       - name: Upload Categories
         working-directory: ./uploader

--- a/.github/workflows/test-database.yml
+++ b/.github/workflows/test-database.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.25'
 
     - name: Run docker compose
       run: docker compose up -d --build --wait

--- a/.github/workflows/test-executor.yml
+++ b/.github/workflows/test-executor.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.25'
 
     - name: Run docker compose
       run: docker compose up -d --build --wait

--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "24"
 
       - run: npm ci
         working-directory: ./frontend

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
 
       # Use the same docker runtime tuning as judge workflow
       # Install crun and configure Docker daemon for cgroupfs

--- a/.github/workflows/test-judge.yml
+++ b/.github/workflows/test-judge.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.25'
 
     - name: Run docker compose
       run: docker compose up -d --build --wait

--- a/.github/workflows/test-langs.yml
+++ b/.github/workflows/test-langs.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.25'
 
     - name: Run docker compose
       run: docker compose up -d --build --wait

--- a/.github/workflows/test-migrator.yml
+++ b/.github/workflows/test-migrator.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.25'
 
     - name: Run docker compose
       run: docker compose up -d --build --wait

--- a/.github/workflows/test-rejudge-tool.yml
+++ b/.github/workflows/test-rejudge-tool.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.25'
 
     - name: Rejudge tool module test
       run: go test . -v

--- a/.github/workflows/test-restapi.yml
+++ b/.github/workflows/test-restapi.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.25'
 
     - name: Run docker compose
       run: docker compose up -d --build --wait

--- a/.github/workflows/test-storage.yml
+++ b/.github/workflows/test-storage.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.25'
 
     - name: Run docker compose
       run: docker compose up -d --build --wait

--- a/.github/workflows/test-uploader.yml
+++ b/.github/workflows/test-uploader.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.25'
 
     - name: Run docker compose
       run: docker compose up -d --build --wait

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: check-added-large-files
   - repo: https://github.com/golangci/golangci-lint
     # Pin to a specific golangci-lint release tag
-    rev: v2.4.0
+    rev: v2.11.4
     hooks:
       - id: golangci-lint-config-verify
       - id: golangci-lint-full

--- a/Dockerfile.APIREST
+++ b/Dockerfile.APIREST
@@ -1,4 +1,4 @@
-FROM golang:1.24 as builder
+FROM golang:1.25 as builder
 
 WORKDIR /go/src/github.com/yosupo06/library-checker-judge/restapi
 

--- a/Dockerfile.JUDGE
+++ b/Dockerfile.JUDGE
@@ -1,4 +1,4 @@
-FROM golang:1.24 AS builder
+FROM golang:1.25 AS builder
 
 WORKDIR /go/src/github.com/yosupo06/library-checker-judge
 

--- a/Dockerfile.METRICS
+++ b/Dockerfile.METRICS
@@ -1,4 +1,4 @@
-FROM golang:1.24 as builder
+FROM golang:1.25 as builder
 
 WORKDIR /workspace
 

--- a/Dockerfile.MIGRATOR
+++ b/Dockerfile.MIGRATOR
@@ -1,4 +1,4 @@
-FROM golang:1.24 as builder
+FROM golang:1.25 as builder
 
 WORKDIR /go/src/github.com/yosupo06/library-checker-judge/migrator
 

--- a/cloudrun/taskqueue-metrics/go.mod
+++ b/cloudrun/taskqueue-metrics/go.mod
@@ -2,7 +2,7 @@ module github.com/yosupo06/library-checker-judge/cloudrun/taskqueue-metrics
 
 go 1.24.0
 
-toolchain go1.24.7
+toolchain go1.25.9
 
 replace github.com/yosupo06/library-checker-judge/database => ../../database
 

--- a/compose.yml
+++ b/compose.yml
@@ -25,7 +25,7 @@ services:
       retries: 30
 
   db:
-    image: postgres:11.3
+    image: postgres:15
     ports:
       - 5432:5432
     environment:

--- a/firebase/Dockerfile
+++ b/firebase/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-bullseye
+FROM node:24-bookworm
 
 RUN apt update && apt install -y openjdk-17-jdk
 

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.24.7
+go 1.25.0
 
 use (
 	./cloudrun/taskqueue-metrics


### PR DESCRIPTION
## Summary
- update Go Docker/CI/toolchain references from 1.24 to 1.25
- update golangci-lint pre-commit hook to a Go 1.25-compatible release
- update Node runtime references from 18 to 24
- update local PostgreSQL compose image from 11.3 to 15 to match the Cloud SQL instance
- update Cloud SQL Auth Proxy downloads from v2.1.2 to v2.21.3

Part of #590, task 2.

## PostgreSQL 15 support check
- PostgreSQL community support: PG15 is still supported; final release date is November 11, 2027.
- Cloud SQL regular support: PG15 enters extended support on February 1, 2028, with deprecation on February 1, 2031.
- Sources: https://www.postgresql.org/support/versioning/ and https://cloud.google.com/sql/docs/postgres/db-versions

## Verification
- `pre-commit run golangci-lint-config-verify --all-files`
- `pre-commit run golangci-lint-full --all-files`
- `go test ./...` in `restapi/`
- `go test ./...` in `database/` against a fresh temporary PostgreSQL 15 container
- `go test ./...` in `storage/`
- `go test ./...` in `cloudrun/taskqueue-metrics/`
- `docker build -f Dockerfile.APIREST .`
- `docker build -f Dockerfile.MIGRATOR .`
- `docker build -f Dockerfile.METRICS .`
- `docker build -f Dockerfile.JUDGE .`
- `docker build -f firebase/Dockerfile firebase`
- `COMPOSE_PROJECT_NAME=lcj-pg15-test docker compose up -d db --wait` and `show server_version;` returned PostgreSQL 15.17

## Notes
- Go 1.26 was initially tried, but current golangci-lint pre-commit binaries are still built with Go 1.25 and reject a Go 1.26 target. This PR uses Go 1.25 as the conservative supported runtime update.
- Existing local PostgreSQL 11 Docker volumes will not start directly under PostgreSQL 15. Use a fresh local volume, dump/restore, or `pg_upgrade` for local data migration.