### PR TITLE
[codex] Add Dockerfile build checks

### DIFF
--- a/.github/workflows/test-dockerfiles.yml
+++ b/.github/workflows/test-dockerfiles.yml
@@ -1,0 +1,31 @@
+name: Test Dockerfiles
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'Dockerfile.*'
+      - 'firebase/Dockerfile'
+      - 'langs/Dockerfile.*'
+      - 'tools/check-dockerfiles.sh'
+      - '.github/workflows/test-dockerfiles.yml'
+  pull_request:
+    paths:
+      - 'Dockerfile.*'
+      - 'firebase/Dockerfile'
+      - 'langs/Dockerfile.*'
+      - 'tools/check-dockerfiles.sh'
+      - '.github/workflows/test-dockerfiles.yml'
+
+jobs:
+  dockerfile-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Run Dockerfile build checks
+        run: tools/check-dockerfiles.sh

--- a/Dockerfile.APIREST
+++ b/Dockerfile.APIREST
@@ -1,4 +1,4 @@
-FROM golang:1.25 as builder
+FROM golang:1.25 AS builder
 
 WORKDIR /go/src/github.com/yosupo06/library-checker-judge/restapi
 

--- a/Dockerfile.METRICS
+++ b/Dockerfile.METRICS
@@ -1,4 +1,4 @@
-FROM golang:1.25 as builder
+FROM golang:1.25 AS builder
 
 WORKDIR /workspace
 

--- a/Dockerfile.MIGRATOR
+++ b/Dockerfile.MIGRATOR
@@ -1,4 +1,4 @@
-FROM golang:1.25 as builder
+FROM golang:1.25 AS builder
 
 WORKDIR /go/src/github.com/yosupo06/library-checker-judge/migrator
 

--- a/langs/Dockerfile.CRYSTAL
+++ b/langs/Dockerfile.CRYSTAL
@@ -1,4 +1,4 @@
-FROM rust:alpine as init-builder
+FROM rust:alpine AS init-builder
 WORKDIR /library-checker-init
 COPY init /library-checker-init
 RUN cargo build --release --target=x86_64-unknown-linux-musl

--- a/langs/Dockerfile.CSHARP
+++ b/langs/Dockerfile.CSHARP
@@ -1,4 +1,4 @@
-FROM rust:alpine as init-builder
+FROM rust:alpine AS init-builder
 WORKDIR /library-checker-init
 COPY init /library-checker-init
 RUN cargo build --release --target=x86_64-unknown-linux-musl

--- a/langs/Dockerfile.GCC
+++ b/langs/Dockerfile.GCC
@@ -1,9 +1,9 @@
-FROM rust:alpine as init-builder
+FROM rust:alpine AS init-builder
 WORKDIR /library-checker-init
 COPY init /library-checker-init
 RUN cargo build --release --target=x86_64-unknown-linux-musl
 
-FROM ubuntu as builder
+FROM ubuntu AS builder
 RUN apt-get update
 RUN apt-get install -y git
 WORKDIR /workdir

--- a/langs/Dockerfile.GOLANG
+++ b/langs/Dockerfile.GOLANG
@@ -1,4 +1,4 @@
-FROM rust:alpine as init-builder
+FROM rust:alpine AS init-builder
 WORKDIR /library-checker-init
 COPY init /library-checker-init
 RUN cargo build --release --target=x86_64-unknown-linux-musl

--- a/langs/Dockerfile.JAVA
+++ b/langs/Dockerfile.JAVA
@@ -1,4 +1,4 @@
-FROM rust:alpine as init-builder
+FROM rust:alpine AS init-builder
 WORKDIR /library-checker-init
 COPY init /library-checker-init
 RUN cargo build --release --target=x86_64-unknown-linux-musl

--- a/langs/Dockerfile.LDC
+++ b/langs/Dockerfile.LDC
@@ -1,4 +1,4 @@
-FROM rust:alpine as init-builder
+FROM rust:alpine AS init-builder
 WORKDIR /library-checker-init
 COPY init /library-checker-init
 RUN cargo build --release --target=x86_64-unknown-linux-musl

--- a/langs/Dockerfile.LISP
+++ b/langs/Dockerfile.LISP
@@ -1,4 +1,4 @@
-FROM rust:alpine as init-builder
+FROM rust:alpine AS init-builder
 WORKDIR /library-checker-init
 COPY init /library-checker-init
 RUN cargo build --release --target=x86_64-unknown-linux-musl

--- a/langs/Dockerfile.NIM
+++ b/langs/Dockerfile.NIM
@@ -1,4 +1,4 @@
-FROM rust:alpine as init-builder
+FROM rust:alpine AS init-builder
 WORKDIR /library-checker-init
 COPY init /library-checker-init
 RUN cargo build --release --target=x86_64-unknown-linux-musl

--- a/langs/Dockerfile.PYPY
+++ b/langs/Dockerfile.PYPY
@@ -1,4 +1,4 @@
-FROM rust:alpine as init-builder
+FROM rust:alpine AS init-builder
 WORKDIR /library-checker-init
 COPY init /library-checker-init
 RUN cargo build --release --target=x86_64-unknown-linux-musl

--- a/langs/Dockerfile.PYTHON3
+++ b/langs/Dockerfile.PYTHON3
@@ -1,4 +1,4 @@
-FROM rust:alpine as init-builder
+FROM rust:alpine AS init-builder
 WORKDIR /library-checker-init
 COPY init /library-checker-init
 RUN cargo build --release --target=x86_64-unknown-linux-musl

--- a/langs/Dockerfile.RUBY
+++ b/langs/Dockerfile.RUBY
@@ -1,4 +1,4 @@
-FROM rust:alpine as init-builder
+FROM rust:alpine AS init-builder
 WORKDIR /library-checker-init
 COPY init /library-checker-init
 RUN cargo build --release --target=x86_64-unknown-linux-musl

--- a/langs/Dockerfile.RUST
+++ b/langs/Dockerfile.RUST
@@ -1,4 +1,4 @@
-FROM rust:alpine as init-builder
+FROM rust:alpine AS init-builder
 WORKDIR /library-checker-init
 COPY init /library-checker-init
 RUN cargo build --release --target=x86_64-unknown-linux-musl

--- a/langs/Dockerfile.SWIFT
+++ b/langs/Dockerfile.SWIFT
@@ -1,4 +1,4 @@
-FROM rust:alpine as init-builder
+FROM rust:alpine AS init-builder
 WORKDIR /library-checker-init
 COPY init /library-checker-init
 RUN cargo build --release --target=x86_64-unknown-linux-musl

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,19 @@
+# Tools
+
+This directory contains maintenance and operator utilities that are not part of
+the deployed runtime.
+
+Use `tools/` for small executables or scripts that are run manually by
+operators, or by scheduled/one-shot automation, and whose failure does not leave
+the main application in an incomplete deploy state.
+
+Examples:
+
+- `check-dockerfiles.sh`: Docker BuildKit build checks for Dockerfiles.
+- `rejudge/`: operator CLI for queueing existing submissions for rejudge.
+- `prune_gce_images.py`: housekeeping script for removing old judge VM images.
+
+Do not put deploy/runtime components here. Components such as `migrator/`,
+`uploader/`, `restapi/`, `judge/`, and `cloudrun/taskqueue-metrics/` are part of
+the application deploy or runtime lifecycle, so they should remain in their
+domain-specific top-level directories.

--- a/tools/check-dockerfiles.sh
+++ b/tools/check-dockerfiles.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+check_dockerfile() {
+  local dockerfile="$1"
+  local context="$2"
+
+  echo "Checking ${dockerfile}"
+  docker buildx build \
+    --check \
+    --build-arg 'BUILDKIT_DOCKERFILE_CHECK=error=true' \
+    -f "${dockerfile}" \
+    "${context}"
+}
+
+for dockerfile in Dockerfile.* firebase/Dockerfile; do
+  check_dockerfile "${dockerfile}" .
+done
+
+for dockerfile in langs/Dockerfile.*; do
+  check_dockerfile "${dockerfile}" langs
+done


### PR DESCRIPTION
## Summary

- Normalize Dockerfile stage aliases to use `AS`, matching Docker BuildKit's casing check.
- Add `tools/check-dockerfiles.sh` to run Docker BuildKit build checks over root, Firebase, and language Dockerfiles without building images.
- Add `tools/README.md` to document where maintenance/operator utilities belong.
- Add a GitHub Actions workflow so Dockerfile build-check warnings fail PRs instead of being noticed only locally.

## Validation

- `tools/check-dockerfiles.sh`
- `bash -n tools/check-dockerfiles.sh`
- `pre-commit run check-yaml --files .github/workflows/test-dockerfiles.yml`
- `pre-commit run actionlint --files .github/workflows/test-dockerfiles.yml`