### PR TITLE
[codex] Separate OpenAPI codegen checks from Docker builds

### DIFF
--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -26,8 +26,6 @@ jobs:
 
       - run: npm ci
         working-directory: ./frontend
-      - run: npm run openapi:gen
-        working-directory: ./frontend
       - run: npm run coverage
         working-directory: ./frontend
       - run: npm run prettier:check

--- a/.github/workflows/test-openapi-codegen.yml
+++ b/.github/workflows/test-openapi-codegen.yml
@@ -1,0 +1,62 @@
+name: Test OpenAPI Codegen
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'restapi/openapi/**'
+      - 'restapi/go.mod'
+      - 'restapi/go.sum'
+      - 'restapi/internal/api/api.gen.go'
+      - 'frontend/package.json'
+      - 'frontend/package-lock.json'
+      - 'frontend/src/openapi/types.ts'
+      - '.github/workflows/test-openapi-codegen.yml'
+  pull_request:
+    paths:
+      - 'restapi/openapi/**'
+      - 'restapi/go.mod'
+      - 'restapi/go.sum'
+      - 'restapi/internal/api/api.gen.go'
+      - 'frontend/package.json'
+      - 'frontend/package-lock.json'
+      - 'frontend/src/openapi/types.ts'
+      - '.github/workflows/test-openapi-codegen.yml'
+
+jobs:
+  restapi-openapi-codegen:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+
+      - name: Generate REST API bindings
+        run: go generate ./...
+        working-directory: ./restapi
+
+      - name: Check generated REST API files
+        run: git diff --exit-code -- restapi
+
+  frontend-openapi-codegen:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - run: npm ci
+        working-directory: ./frontend
+
+      - name: Generate frontend OpenAPI types
+        run: npm run openapi:gen
+        working-directory: ./frontend
+
+      - name: Check generated frontend OpenAPI types
+        run: git diff --exit-code -- frontend/src/openapi/types.ts

--- a/.github/workflows/test-restapi.yml
+++ b/.github/workflows/test-restapi.yml
@@ -29,5 +29,5 @@ jobs:
       run: docker compose up -d --build --wait
 
     - name: REST API module test
-      run: go test . -v
+      run: go test -mod=readonly . -v
       working-directory: ./restapi

--- a/Dockerfile.APIREST
+++ b/Dockerfile.APIREST
@@ -19,11 +19,8 @@ COPY ./restapi/. /go/src/github.com/yosupo06/library-checker-judge/restapi/
 COPY ./database/. /go/src/github.com/yosupo06/library-checker-judge/database/
 COPY ./langs/. /go/src/github.com/yosupo06/library-checker-judge/langs/
 
-# Generate server/types from OpenAPI before build (single source of truth)
-RUN go generate ./... && go mod tidy
-
 # Build static binary
-RUN CGO_ENABLED=0 GOOS=linux go build .
+RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly .
 
 FROM alpine
 RUN apk --no-cache add ca-certificates

--- a/Dockerfile.JUDGE
+++ b/Dockerfile.JUDGE
@@ -14,7 +14,7 @@ COPY ./storage ./storage
 COPY ./langs ./langs
 
 WORKDIR /go/src/github.com/yosupo06/library-checker-judge/judge
-RUN CGO_ENABLED=0 GOOS=linux go build -o /out/judge .
+RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -o /out/judge .
 
 # Use docker CLI image so the judge can call `docker` against the host daemon
 FROM docker:27-cli

--- a/Dockerfile.METRICS
+++ b/Dockerfile.METRICS
@@ -11,7 +11,7 @@ COPY ./cloudrun/taskqueue-metrics ./cloudrun/taskqueue-metrics
 COPY ./database ./database
 
 WORKDIR /workspace/cloudrun/taskqueue-metrics
-RUN CGO_ENABLED=0 GOOS=linux go build -o /workspace/taskqueue-metrics .
+RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly -o /workspace/taskqueue-metrics .
 
 FROM alpine
 RUN apk --no-cache add ca-certificates

--- a/Dockerfile.MIGRATOR
+++ b/Dockerfile.MIGRATOR
@@ -13,7 +13,7 @@ RUN go mod download
 COPY ./migrator/. /go/src/github.com/yosupo06/library-checker-judge/migrator/
 COPY ./database/. /go/src/github.com/yosupo06/library-checker-judge/database/
 
-RUN CGO_ENABLED=0 GOOS=linux go build .
+RUN CGO_ENABLED=0 GOOS=linux go build -mod=readonly .
 
 FROM alpine
 RUN apk --no-cache add ca-certificates

--- a/restapi/README.md
+++ b/restapi/README.md
@@ -12,7 +12,7 @@
 
 ## 1) Docker Compose で動かす（おすすめ）
 
-依存サービス（PostgreSQL, Cloud Storage エミュレータ, Firebase emulator など）と一緒に立ち上げます。OpenAPI からのコード生成も Docker イメージ内で自動実行されます。
+依存サービス（PostgreSQL, Cloud Storage エミュレータ, Firebase emulator など）と一緒に立ち上げます。OpenAPI から生成されたコードはコミット済みのビルド入力として使います。
 
 ```bash
 # ルート: library-checker-judge/
@@ -41,23 +41,14 @@ docker compose up -d --build db db-init gcs api-rest
 
 ## 2) Go 単体でローカル実行（Docker なし）
 
-OpenAPI のコード生成が必要です。生成後は普通に `go run` で起動できます。
+OpenAPI 定義を変更した場合はコード生成が必要です。生成後は普通に `go run` で起動できます。
 
 ### 前提
 - Go 1.24+
 - PostgreSQL が動いていること（DB 初期化が未実施なら後述のマイグレーションを実行）
 
-### OpenAPI コード生成（補完を効かせたい人向け）
-エディタで補完を効かせるには、生成コード（`internal/api/api.gen.go`）が手元に存在する必要があります。以下のいずれかを実行してください。
-
-- シンプル: `make gen`
-
-```bash
-cd library-checker-judge/restapi
-make gen   # = go generate ./... && go mod tidy
-```
-
-- 直接 `go generate` を使う:
+### OpenAPI コード生成
+`restapi/openapi/openapi.yaml` を変更したら、生成コード（`internal/api/api.gen.go`）も更新してコミットしてください。
 
 ```bash
 cd library-checker-judge/restapi
@@ -105,7 +96,7 @@ curl "http://localhost:12381/ranking?skip=0&limit=100"
 
 ## よくあるハマりどころ / トラブルシュート
 - ビルド時に `missing go.sum entry for ... oapi-codegen ...` と出る
-  - 上記「OpenAPI コード生成」後に `go mod tidy` を実行してください。
+  - 上記「OpenAPI コード生成」後に `go mod tidy` を実行し、`go.mod` / `go.sum` の差分を確認してください。
 - DB 接続に失敗する
   - `PGHOST, PGPORT, PGDATABASE, PGUSER, PGPASSWORD` が正しいか確認してください。
   - Docker Compose を使っている場合は `PGHOST=db`（デフォルト）になります。


### PR DESCRIPTION
## Summary

- Add a dedicated OpenAPI codegen workflow that regenerates REST API bindings and frontend OpenAPI types, then fails on uncommitted diffs.
- Stop running `go generate ./...` and `go mod tidy` inside `Dockerfile.APIREST`; build with `-mod=readonly` instead.
- Use `-mod=readonly` for the other Go Docker image builds as well (`Dockerfile.JUDGE`, `Dockerfile.MIGRATOR`, `Dockerfile.METRICS`).
- Remove frontend OpenAPI generation from the general frontend test workflow and document generated REST API code as a committed build input.

## Why

Docker builds should consume committed generated artifacts instead of mutating code or module metadata during image build. This makes stale generated files fail in a clear CI check and keeps Docker builds reproducible.

Closes #592.

## Validation

- `go generate ./... && git diff --exit-code -- go.mod go.sum internal/api/api.gen.go` in `restapi`
- `go test -mod=readonly . -v` in `restapi`
- `npm run openapi:gen && git diff --exit-code -- src/openapi/types.ts` in `frontend`
- `go build -mod=readonly .` in `judge`, `migrator`, and `cloudrun/taskqueue-metrics`
- `tools/check-dockerfiles.sh`
- `docker build -f Dockerfile.APIREST .`
- `docker build -f Dockerfile.JUDGE .`
- `docker build -f Dockerfile.MIGRATOR .`
- `docker build -f Dockerfile.METRICS .`