### PR TITLE
fix(ci): prune stale base images

### DIFF
--- a/.github/workflows/judge-image-prune.yml
+++ b/.github/workflows/judge-image-prune.yml
@@ -67,13 +67,28 @@ jobs:
 
       - name: Prune images
         run: |
-          ARGS=(
-            --project "${{ inputs.env }}-library-checker-project"
-            --family v3-judge-image
-            --keep 3
-            --min-age-days 14
-          )
+          DRY_RUN_ARGS=()
           if [[ "${{ inputs.dry-run }}" == "true" ]]; then
-            ARGS+=(--dry-run)
+            DRY_RUN_ARGS+=(--dry-run)
           fi
-          python3 ./tools/prune_gce_images.py "${ARGS[@]}"
+
+          python3 ./tools/prune_gce_images.py \
+            --project "${{ inputs.env }}-library-checker-project" \
+            --family v3-judge-image \
+            --keep 3 \
+            --min-age-days 14 \
+            "${DRY_RUN_ARGS[@]}"
+
+          python3 ./tools/prune_gce_images.py \
+            --project "${{ inputs.env }}-library-checker-project" \
+            --family "v3-${{ inputs.env }}-base-image" \
+            --keep 3 \
+            --min-age-days 14 \
+            "${DRY_RUN_ARGS[@]}"
+
+          python3 ./tools/prune_gce_images.py \
+            --project "${{ inputs.env }}-library-checker-project" \
+            --name-regex '^v3-tmp-base-image-' \
+            --keep 0 \
+            --min-age-days 14 \
+            "${DRY_RUN_ARGS[@]}"

--- a/docs/judge-image-managing.md
+++ b/docs/judge-image-managing.md
@@ -5,7 +5,7 @@
 - `judge-image-build.yml` はベースイメージの更新（任意）と、環境ごとのジャッジイメージ生成を常に担当します。
 - ワークフローは Terraform の出力に依存しており、Google Cloud の認証、イメージファミリー、ストレージ/データベース設定を決定します。
 - イメージは `${ENV}-library-checker-project` GCP プロジェクトに保存され、ベース層は `v3-${ENV}-base-image`、ジャッジランタイムは Terraform 出力で指定されるファミリーを利用します。
-- 古いジャッジイメージは `judge-image-prune.yml` が `tools/prune_gce_images.py` を呼び出して最近のものを保持しつつ古いものを削除します。
+- 古いジャッジ/ベース/一時ベースイメージは `judge-image-prune.yml` が `tools/prune_gce_images.py` を呼び出して最近のものを保持しつつ古いものを削除します。
 
 ## judge-image-build ワークフロー
 - トリガーモード: `workflow_call` による再利用（`env` 入力が必須）と、`env`（`dev` または `prod`）および `build-base` フラグを受け取る手動の `workflow_dispatch`。
@@ -54,11 +54,11 @@
 - `judge.service` が Docker と Cloud SQL Proxy の両方に依存するよう構成し、ジャッジプロセスに必要な環境変数を登録します。
 
 ## イメージのクリーンアップ
-- `judge-image-prune.yml` は UTC 18:00 に毎日実行され（手動トリガーも可能）、ジャッジイメージを整理します。
-- ワークフローはビルドジョブと同じ認証手順を踏み、その後 `tools/prune_gce_images.py` を次のパラメータで呼び出します:
-  - `--family v3-judge-image`
-  - `--keep 3`
-  - `--min-age-days 14`
+- `judge-image-prune.yml` は UTC 18:00 に毎日実行され（手動トリガーも可能）、GCE のカスタムイメージを整理します。
+- ワークフローはビルドジョブと同じ認証手順を踏み、その後 `tools/prune_gce_images.py` を次の対象に対して呼び出します:
+  - `--family v3-judge-image --keep 3 --min-age-days 14`
+  - `--family v3-${env}-base-image --keep 3 --min-age-days 14`
+  - `--name-regex '^v3-tmp-base-image-' --keep 0 --min-age-days 14`
   - ワークフロー入力の `--dry-run` フラグ（任意）
 - スクリプトは `creationTimestamp` 順にイメージを並べ、新しい `keep` 件を残し、最小経過日数の条件を満たした古いイメージを削除します。
 
@@ -66,4 +66,4 @@
 - `judge-image-build` を手動で起動する際はベースイメージの変更有無を確認し、最新の `v3-${env}-base-image` を再利用したい場合は `build-base` をスキップして実行時間を短縮してください。
 - ワークフローを動かす前に Terraform のステート/ワークスペースの出力が最新であることを確認してください。これらはサービスアカウント、イメージファミリー名、ストレージ/データベース設定を提供します。
 - 新しいベースイメージを公開すると同じワークフロー内のジャッジジョブが自動的にそれを取り込みます。Packer のソースがファミリーの最新イメージを参照するためです。
-- クリーンアップはジャッジイメージファミリーのみに適用されます。ベースイメージは GCE ファミリールールに従って蓄積されるため、不要な増加を避けるために Base ジョブの実行は必要な場合に限定してください。
+- クリーンアップはジャッジイメージファミリー、環境別のベースイメージファミリー、一時ベースイメージ名に適用されます。不要な増加を避けるために Base ジョブの実行は必要な場合に限定してください。

--- a/tools/README.md
+++ b/tools/README.md
@@ -11,7 +11,7 @@ Examples:
 
 - `check-dockerfiles.sh`: Docker BuildKit build checks for Dockerfiles.
 - `rejudge/`: operator CLI for queueing existing submissions for rejudge.
-- `prune_gce_images.py`: housekeeping script for removing old judge VM images.
+- `prune_gce_images.py`: housekeeping script for removing old custom GCE images.
 
 Do not put deploy/runtime components here. Components such as `migrator/`,
 `uploader/`, `restapi/`, `judge/`, and `cloudrun/taskqueue-metrics/` are part of

--- a/tools/prune_gce_images.py
+++ b/tools/prune_gce_images.py
@@ -33,10 +33,12 @@ class ImageEntry:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Delete old images from a GCE image family",
+        description="Delete old GCE images matching a family or name regex",
     )
     parser.add_argument("--project", required=True, help="GCP project ID")
-    parser.add_argument("--family", required=True, help="GCE image family name")
+    selector = parser.add_mutually_exclusive_group(required=True)
+    selector.add_argument("--family", help="GCE image family name")
+    selector.add_argument("--name-regex", help="GCE image name regex")
     parser.add_argument("--keep", type=int, default=10,
                         help="Number of most recent images to keep (default: 10)")
     parser.add_argument("--min-age-days", type=int, default=14,
@@ -53,14 +55,26 @@ def validate_args(args: argparse.Namespace) -> None:
         sys.exit("--min-age-days must be a non-negative integer")
 
 
-def run_gcloud_list(project: str, family: str) -> List[ImageEntry]:
+def image_filter(args: argparse.Namespace) -> str:
+    if args.family:
+        return f"family={args.family}"
+    return f"name~{args.name_regex}"
+
+
+def selector_label(args: argparse.Namespace) -> str:
+    if args.family:
+        return f"family '{args.family}'"
+    return f"name regex '{args.name_regex}'"
+
+
+def run_gcloud_list(project: str, filter_expr: str) -> List[ImageEntry]:
     cmd = [
         "gcloud",
         "compute",
         "images",
         "list",
         f"--project={project}",
-        f"--filter=family={family}",
+        f"--filter={filter_expr}",
         "--no-standard-images",
         "--format=value(name,creationTimestamp)",
         "--sort-by=~creationTimestamp",
@@ -95,15 +109,15 @@ def run_gcloud_list(project: str, family: str) -> List[ImageEntry]:
 
 def prune_images(entries: Iterable[ImageEntry], keep: int,
                  min_age_days: int, dry_run: bool,
-                 project: str, family: str) -> None:
+                 project: str, label: str) -> None:
     entries_list = list(entries)
     total = len(entries_list)
     if total == 0:
-        print(f"No images found for family '{family}' in project '{project}'.")
+        print(f"No images found for {label} in project '{project}'.")
         return
 
     print(
-        f"Found {total} images for family '{family}' in project '{project}'. "
+        f"Found {total} images for {label} in project '{project}'. "
         f"Keeping the latest {keep} images."
     )
     if total <= keep:
@@ -154,14 +168,14 @@ def prune_images(entries: Iterable[ImageEntry], keep: int,
 def main() -> None:
     args = parse_args()
     validate_args(args)
-    entries = run_gcloud_list(args.project, args.family)
+    entries = run_gcloud_list(args.project, image_filter(args))
     prune_images(
         entries,
         args.keep,
         args.min_age_days,
         args.dry_run,
         args.project,
-        args.family,
+        selector_label(args),
     )
 
 


### PR DESCRIPTION
## Summary

- extend the judge image prune workflow to prune environment base image families as well as temporary base images
- allow `tools/prune_gce_images.py` to select images by either family or name regex
- update operator documentation for the broader cleanup scope

## Validation

- `python3 -m py_compile tools/prune_gce_images.py`
- `git diff --check`
- local dry-run exercise of `prune_images` with dummy image entries for `keep=1` and `keep=0`